### PR TITLE
Don't enumerate classes in META-INF

### DIFF
--- a/src/main/kotlin/com/jakewharton/dex/DexMethods.kt
+++ b/src/main/kotlin/com/jakewharton/dex/DexMethods.kt
@@ -53,12 +53,12 @@ class DexMethods private constructor() {
                 zis.entries().forEach {
                   if (it.name.endsWith(".dex")) {
                     collection.dexes += zis.readBytes()
-                  } else if (it.name.endsWith(".class")) {
+                  } else if (it.name.endsWith(".class") && !it.name.startsWith("META-INF/")) {
                     collection.classes += zis.readBytes()
                   } else if (it.name.endsWith(".jar")) {
                     ZipInputStream(ByteArrayInputStream(zis.readBytes())).use { jar ->
                       jar.entries().forEach {
-                        if (it.name.endsWith(".class")) {
+                        if (it.name.endsWith(".class") && !it.name.startsWith("META-INF/")) {
                           collection.classes += jar.readBytes()
                         }
                       }


### PR DESCRIPTION
This helps to avoid exceptions on multi-release jars where
module-info.class file is stored in META-INF/versions/9, since
com.android.dex apparently can't handle these class files