### PR TITLE
Hide lambda class and accessor methods numbers if flag is set

### DIFF
--- a/src/main/kotlin/com/jakewharton/dex/DexMember.kt
+++ b/src/main/kotlin/com/jakewharton/dex/DexMember.kt
@@ -52,14 +52,21 @@ data class DexMethod(
   override fun render(hideSyntheticNumbers: Boolean): String {
     val method = if (hideSyntheticNumbers && name.matches(SYNTHETIC_SUFFIX)) {
       name.substring(0, name.lastIndexOf('$'))
+    } else if (hideSyntheticNumbers && name.matches(LAMBDA_ACCESSOR)) {
+      name.replace(NUMBER_SEGMENT, "")
     } else name
+
+    val declaringTypeName = if (hideSyntheticNumbers && declaringType.matches(SYNTHETIC_SUFFIX)) {
+      declaringType.substring(0, declaringType.lastIndexOf('$'))
+    } else declaringType
+
     val parameters = parameterTypes.joinToString(", ") { it.substringAfterLast('.') }
 
     if (returnType == "void") {
-      return "$declaringType $method($parameters)"
+      return "$declaringTypeName $method($parameters)"
     }
     val returnName = returnType.substringAfterLast('.')
-    return "$declaringType $method($parameters) → $returnName"
+    return "$declaringTypeName $method($parameters) → $returnName"
   }
 
   override fun toString() = render()
@@ -74,6 +81,8 @@ data class DexMethod(
 
   private companion object {
     val SYNTHETIC_SUFFIX = ".*?\\$\\d+".toRegex()
+    val LAMBDA_ACCESSOR = "lambda(\\$[a-zA-Z0-9_]+)*\\$\\d+(\\$[a-zA-Z0-9_]+)*".toRegex()
+    val NUMBER_SEGMENT = "\\$\\d+".toRegex()
     val COMPARATOR = compareBy(DexMethod::name)
         .thenBy(comparingValues(), DexMethod::parameterTypes)
         .thenBy(DexMethod::returnType)

--- a/src/test/kotlin/com/jakewharton/dex/DexMethodTest.kt
+++ b/src/test/kotlin/com/jakewharton/dex/DexMethodTest.kt
@@ -29,6 +29,38 @@ class DexMethodTest {
         .isEqualTo("com.example.Foo access() → Bar")
   }
 
+  @Test fun renderWithLambdas() {
+    val lambdaAccessor =
+      DexMethod(
+          "com.example.Foo", "lambda_12\$methods$15\$OuterClass_12", emptyList(), "com.example.Bar"
+      )
+    assertThat(lambdaAccessor.render())
+        .isEqualTo("com.example.Foo lambda_12\$methods$15\$OuterClass_12() → Bar")
+
+    val lambdaClass =
+      DexMethod("com.example.Foo$\$Lambda$15", "<init>", emptyList(), "void")
+    assertThat(lambdaClass.render())
+        .isEqualTo("com.example.Foo$\$Lambda$15 <init>()")
+  }
+
+  @Test fun renderHidingLambdas() {
+    val method = DexMethod("com.example.Foo", "bar", emptyList(), "com.example.Bar")
+    assertThat(method.render(hideSyntheticNumbers = true))
+        .isEqualTo("com.example.Foo bar() → Bar")
+
+    val lambdaAccessor =
+      DexMethod(
+          "com.example.Foo", "lambda\$methods_12$15\$OuterClass_12", emptyList(), "com.example.Bar"
+      )
+    assertThat(lambdaAccessor.render(hideSyntheticNumbers = true))
+        .isEqualTo("com.example.Foo lambda\$methods_12\$OuterClass_12() → Bar")
+
+    val lambdaClass =
+      DexMethod("com.example.Foo$\$Lambda$15", "<init>", emptyList(), "void")
+    assertThat(lambdaClass.render(hideSyntheticNumbers = true))
+        .isEqualTo("com.example.Foo$\$Lambda <init>()")
+  }
+
   @Test fun compareToSame() {
     val one = DexMethod("com.example.Foo", "bar", emptyList(), "com.example.Bar")
     val two = DexMethod("com.example.Foo", "bar", emptyList(), "com.example.Bar")


### PR DESCRIPTION
Closes #49 

Here's the after (see #49 for the before):
```
@@ -32569,0 +32570,5 @@
+com.squareup.cash.ui.MainActivity$$Lambda <clinit>()
+com.squareup.cash.ui.MainActivity$$Lambda <init>()
+com.squareup.cash.ui.MainActivity$$Lambda test(Object) → boolean
+com.squareup.cash.ui.MainActivity$$Lambda <init>(MainActivity)
+com.squareup.cash.ui.MainActivity$$Lambda apply(Object) → Object
@@ -32581,3 +32586,2 @@
-com.squareup.cash.ui.MainActivity$$Lambda <clinit>()
-com.squareup.cash.ui.MainActivity$$Lambda <init>()
-com.squareup.cash.ui.MainActivity$$Lambda test(Object) → boolean
+com.squareup.cash.ui.MainActivity$$Lambda <init>(MainActivity)
+com.squareup.cash.ui.MainActivity$$Lambda apply(Object) → Object
@@ -60033,0 +60038,14 @@
+io.reactivex.internal.operators.maybe.MaybeFlatMapSingle <init>(MaybeSource, Function)
+io.reactivex.internal.operators.maybe.MaybeFlatMapSingle subscribeActual(SingleObserver)
+io.reactivex.internal.operators.maybe.MaybeFlatMapSingle$FlatMapMaybeObserver <init>(SingleObserver, Function)
+io.reactivex.internal.operators.maybe.MaybeFlatMapSingle$FlatMapMaybeObserver dispose()
+io.reactivex.internal.operators.maybe.MaybeFlatMapSingle$FlatMapMaybeObserver get() → Object
+io.reactivex.internal.operators.maybe.MaybeFlatMapSingle$FlatMapMaybeObserver isDisposed() → boolean
+io.reactivex.internal.operators.maybe.MaybeFlatMapSingle$FlatMapMaybeObserver onComplete()
+io.reactivex.internal.operators.maybe.MaybeFlatMapSingle$FlatMapMaybeObserver onError(Throwable)
+io.reactivex.internal.operators.maybe.MaybeFlatMapSingle$FlatMapMaybeObserver onSubscribe(Disposable)
+io.reactivex.internal.operators.maybe.MaybeFlatMapSingle$FlatMapMaybeObserver onSuccess(Object)
+io.reactivex.internal.operators.maybe.MaybeFlatMapSingle$FlatMapSingleObserver <init>(AtomicReference, SingleObserver)
+io.reactivex.internal.operators.maybe.MaybeFlatMapSingle$FlatMapSingleObserver onError(Throwable)
+io.reactivex.internal.operators.maybe.MaybeFlatMapSingle$FlatMapSingleObserver onSubscribe(Disposable)
+io.reactivex.internal.operators.maybe.MaybeFlatMapSingle$FlatMapSingleObserver onSuccess(Object)
```