### PR TITLE
Handle trailing lambda numbers

### DIFF
--- a/diffuse/src/main/kotlin/com/jakewharton/diffuse/Member.kt
+++ b/diffuse/src/main/kotlin/com/jakewharton/diffuse/Member.kt
@@ -85,7 +85,7 @@ private fun Field.withoutSyntheticSuffix(): Field {
 }
 
 private val syntheticMethodSuffix = ".*?\\$\\d+".toRegex()
-private val lambdaMethodNumber = "\\$\\d+\\$".toRegex()
+private val lambdaMethodNumber = "\\$\\d+(\\$|$)".toRegex()
 
 private fun Method.withoutSyntheticSuffix(): Method {
   val newDeclaredType = declaringType.withoutSyntheticSuffix()
@@ -97,9 +97,10 @@ private fun Method.withoutSyntheticSuffix(): Method {
   }
 
   val newName = when {
-    lambdaName -> lambdaMethodNumber.find(name)!!.let { match ->
-      name.removeRange(match.range.first, match.range.last)
-    }
+    lambdaName -> lambdaMethodNumber.find(name)?.let { match ->
+      val endIndex = if (match.range.last == name.lastIndex) name.length else match.range.last
+      name.removeRange(match.range.first, endIndex)
+    } ?: name
     syntheticName -> name.substring(0, name.lastIndexOf('$'))
     else -> name
   }

--- a/diffuse/src/test/kotlin/com/jakewharton/diffuse/DexMethodTest.kt
+++ b/diffuse/src/test/kotlin/com/jakewharton/diffuse/DexMethodTest.kt
@@ -25,11 +25,29 @@ class DexMethodTest {
   @Test fun renderKotlinLambdaFunctionName() {
     val synthetic = Method(fooDescriptor, "lambda\$refreshSessionToken$14\$MainActivity", emptyList(), barDescriptor)
     assertThat(synthetic.toString()).isEqualTo("com.example.Foo lambda\$refreshSessionToken$14\$MainActivity() → Bar")
+    val removedSynthetic = synthetic.withoutSyntheticSuffix()
+    assertThat(removedSynthetic.toString()).isEqualTo("com.example.Foo lambda\$refreshSessionToken\$MainActivity() → Bar")
+  }
+
+  @Test fun renderKotlinLambdaFunctionNameNumberLast() {
+    val synthetic = Method(fooDescriptor, "lambda\$refreshSessionToken$14", emptyList(), barDescriptor)
+    assertThat(synthetic.toString()).isEqualTo("com.example.Foo lambda\$refreshSessionToken$14() → Bar")
+    val removedSynthetic = synthetic.withoutSyntheticSuffix()
+    assertThat(removedSynthetic.toString()).isEqualTo("com.example.Foo lambda\$refreshSessionToken() → Bar")
+  }
+
+  @Test fun renderKotlinInvalidLambdaName() {
+    val synthetic = Method(fooDescriptor, "lambda\$refreshSessionToken", emptyList(), barDescriptor)
+    assertThat(synthetic.toString()).isEqualTo("com.example.Foo lambda\$refreshSessionToken() → Bar")
+    val removedSynthetic = synthetic.withoutSyntheticSuffix()
+    assertThat(removedSynthetic.toString()).isEqualTo("com.example.Foo lambda\$refreshSessionToken() → Bar")
   }
 
   @Test fun renderKotlinLambdaClassName() {
     val synthetic = Method(TypeDescriptor("Lcom/example/Foo$\$Lambda$26;"), "bar", emptyList(), barDescriptor)
     assertThat(synthetic.toString()).isEqualTo("com.example.Foo$\$Lambda$26 bar() → Bar")
+    val removedSynthetic = synthetic.withoutSyntheticSuffix()
+    assertThat(removedSynthetic.toString()).isEqualTo("com.example.Foo$\$Lambda bar() → Bar")
   }
 
   @Test fun compareToSame() {


### PR DESCRIPTION
Also fall back to original name if we do not match something.

Closes #84 