### PR TITLE
Bump picnic version to 0.5.0 to fix trailing newlines

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ buildscript {
       'byteunits': 'com.jakewharton.byteunits:byteunits:0.9.1',
       'asm': 'org.ow2.asm:asm:9.0-beta',
       'diffUtils': 'io.github.java-diff-utils:java-diff-utils:4.7',
-      'picnic': 'com.jakewharton.picnic:picnic:0.3.0',
+      'picnic': 'com.jakewharton.picnic:picnic:0.5.0',
   ]
 
   dependencies {

--- a/reports/src/test/kotlin/com/jakewharton/diffuse/SignaturesDiffTest.kt
+++ b/reports/src/test/kotlin/com/jakewharton/diffuse/SignaturesDiffTest.kt
@@ -21,7 +21,6 @@ class SignaturesDiffTest {
       | SIGNATURES │ old │ new      
       |────────────┼─────┼──────────
       |         V1 │     │ 76317631 
-      |
       |""".trimMargin()
     )
   }
@@ -35,7 +34,6 @@ class SignaturesDiffTest {
       |────────────┼──────────┼──────────
       |         V1 │ 76317631 │ 76317631 
       |         V2 │          │ 76327632 
-      |
       |""".trimMargin()
     )
   }
@@ -50,7 +48,6 @@ class SignaturesDiffTest {
       |         V1 │ 76317631 │ 76317631 
       |         V2 │ 76327632 │          
       |         V3 │          │ 76337633 
-      |
       |""".trimMargin()
     )
   }


### PR DESCRIPTION
Closes #93.