### PR TITLE
Fix "IllegalArgumentException: wrong number of arguments" on `getV4SchemeSigners` call

### DIFF
--- a/diffuse/src/main/rules.txt
+++ b/diffuse/src/main/rules.txt
@@ -26,3 +26,8 @@
 -keepclassmembers class com.android.apksig.internal.** {
   <init>();
 }
+
+# Method called reflectively.
+-keep class com.android.apksig.ApkVerifier$Result {
+    private java.util.List getV4SchemeSigners();
+}

--- a/formats/src/main/kotlin/com/jakewharton/diffuse/format/Signatures.kt
+++ b/formats/src/main/kotlin/com/jakewharton/diffuse/format/Signatures.kt
@@ -59,6 +59,6 @@ data class Signatures(
     private val Result.v4SchemeSigners: List<V4SchemeSignerInfo>
       get() = this::class.java
         .getDeclaredMethod("getV4SchemeSigners").apply { isAccessible = true }
-        .invoke(this, null) as List<V4SchemeSignerInfo>
+        .invoke(this) as List<V4SchemeSignerInfo>
   }
 }


### PR DESCRIPTION
The initial implementation doesn't seem to be valid as it produces:
```
java.lang.IllegalArgumentException: wrong number of arguments
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at com.jakewharton.diffuse.format.Signatures$Companion.getV4SchemeSigners(Signatures.kt:62)
```

Seeing the `getV4SchemeSigners` doesn't take any arguments, I believe the `null` argument should be omitted 👀 

My apologies for not covering the fix with tests, didn't have time really 😬 I'm maintaining a fork of diffuse (due to https://github.com/JakeWharton/diffuse/issues/111#issuecomment-1030749932) and it got caught by [smoke tests](https://github.com/usefulness/diffuse/blob/d025edb59195d338a10b89b9f5771f0cc9efd4ad/diffuse/src/test/kotlin/com/jakewharton/diffuse/FunctionalTest.kt) I added there