### PR TITLE
Adding support for R8/D8 mapping

### DIFF
--- a/reports/src/main/kotlin/com/jakewharton/diffuse/diff/AabDiff.kt
+++ b/reports/src/main/kotlin/com/jakewharton/diffuse/diff/AabDiff.kt
@@ -13,7 +13,10 @@ internal class AabDiff(
     val newModule: Aab.Module,
   ) {
     val archive = ArchiveFilesDiff(oldModule.files, newModule.files, includeCompressed = false)
-    val dex = DexDiff(oldModule.dexes, oldAab.apiMapping, newModule.dexes, newAab.apiMapping)
+    val dex = DexDiff(
+      oldModule.dexes.map { it.withMapping(oldAab.apiMapping) },
+      newModule.dexes.map { it.withMapping(newAab.apiMapping) },
+    )
     val manifest = ManifestDiff(oldModule.manifest, newModule.manifest)
 
     val changed = archive.changed || dex.changed || manifest.changed

--- a/reports/src/main/kotlin/com/jakewharton/diffuse/diff/ApkDiff.kt
+++ b/reports/src/main/kotlin/com/jakewharton/diffuse/diff/ApkDiff.kt
@@ -14,7 +14,10 @@ internal class ApkDiff(
 ) : BinaryDiff {
   val archive = ArchiveFilesDiff(oldApk.files, newApk.files)
   val signatures = SignaturesDiff(oldApk.signatures, newApk.signatures)
-  val dex = DexDiff(oldApk.dexes, oldMapping, newApk.dexes, newMapping)
+  val dex = DexDiff(
+    oldApk.dexes.map { it.withMapping(oldMapping) },
+    newApk.dexes.map { it.withMapping(newMapping) },
+  )
   val arsc = ArscDiff(oldApk.arsc, newApk.arsc)
   val manifest = ManifestDiff(oldApk.manifest, newApk.manifest)
 

--- a/reports/src/main/kotlin/com/jakewharton/diffuse/diff/DexDiff.kt
+++ b/reports/src/main/kotlin/com/jakewharton/diffuse/diff/DexDiff.kt
@@ -1,7 +1,6 @@
 package com.jakewharton.diffuse.diff
 
 import com.jakewharton.diffuse.diffuseTable
-import com.jakewharton.diffuse.format.ApiMapping
 import com.jakewharton.diffuse.format.Dex
 import com.jakewharton.diffuse.format.Field
 import com.jakewharton.diffuse.format.Method
@@ -13,17 +12,9 @@ import com.jakewharton.picnic.TextAlignment.MiddleRight
 import com.jakewharton.picnic.renderText
 
 internal class DexDiff(
-  val oldDexesOriginal: List<Dex>,
-  val oldMapping: ApiMapping,
-  val newDexesOriginal: List<Dex>,
-  val newMapping: ApiMapping
+  val oldDexes: List<Dex>,
+  val newDexes: List<Dex>,
 ) {
-  val oldDexes =if (oldMapping.isEmpty()) oldDexesOriginal else oldDexesOriginal.map{
-    it.withMapping(oldMapping)
-  }
-  val newDexes =if (newMapping.isEmpty()) newDexesOriginal else newDexesOriginal.map{
-    it.withMapping(newMapping)
-  }
   val isMultidex = oldDexes.size > 1 || newDexes.size > 1
 
   val strings = componentDiff(oldDexes, newDexes) { it.strings }

--- a/reports/src/main/kotlin/com/jakewharton/diffuse/diff/DexDiff.kt
+++ b/reports/src/main/kotlin/com/jakewharton/diffuse/diff/DexDiff.kt
@@ -13,11 +13,17 @@ import com.jakewharton.picnic.TextAlignment.MiddleRight
 import com.jakewharton.picnic.renderText
 
 internal class DexDiff(
-  val oldDexes: List<Dex>,
+  val oldDexesOriginal: List<Dex>,
   val oldMapping: ApiMapping,
-  val newDexes: List<Dex>,
-  val newMapping: ApiMapping,
+  val newDexesOriginal: List<Dex>,
+  val newMapping: ApiMapping
 ) {
+  val oldDexes =if (oldMapping.isEmpty()) oldDexesOriginal else oldDexesOriginal.map{
+    it.withMapping(oldMapping)
+  }
+  val newDexes =if (newMapping.isEmpty()) newDexesOriginal else newDexesOriginal.map{
+    it.withMapping(newMapping)
+  }
   val isMultidex = oldDexes.size > 1 || newDexes.size > 1
 
   val strings = componentDiff(oldDexes, newDexes) { it.strings }


### PR DESCRIPTION
It appears that the wiring for deobfuscating R8/D8 proguard maps already exists. The only thing left is to apply those mappings to existing dexes and references.

Closes #96