### PR TITLE
Special case chunk-less resource tables

### DIFF
--- a/formats/src/main/kotlin/com/jakewharton/diffuse/format/Arsc.kt
+++ b/formats/src/main/kotlin/com/jakewharton/diffuse/format/Arsc.kt
@@ -1,5 +1,6 @@
 package com.jakewharton.diffuse.format
 
+import com.google.devrel.gmscore.tools.apk.arsc.BinaryResourceFile
 import com.google.devrel.gmscore.tools.apk.arsc.ResourceTableChunk
 import com.jakewharton.diffuse.io.Input
 
@@ -25,8 +26,14 @@ class Arsc private constructor(
     @JvmStatic
     @JvmName("create")
     fun Input.toArsc(): Arsc {
-      val chunk = toBinaryResourceFile().chunks.single()
-      check(chunk is ResourceTableChunk) { "Root arsc chunk is not a resource table " }
+      // Workaround for https://issuetracker.google.com/issues/322437900.
+      val inputBytes = toByteArray()
+      if (inputBytes.size == 40) {
+        return Arsc(emptyList(), emptyMap())
+      }
+
+      val chunk = BinaryResourceFile(inputBytes).chunks.single()
+      check(chunk is ResourceTableChunk) { "Root arsc chunk is not a resource table" }
 
       val configs = mutableListOf<String>()
       val entries = mutableMapOf<Int, Entry>()

--- a/formats/src/test/kotlin/com/jakewharton/diffuse/format/ArscTest.kt
+++ b/formats/src/test/kotlin/com/jakewharton/diffuse/format/ArscTest.kt
@@ -1,0 +1,58 @@
+package com.jakewharton.diffuse.format
+
+import assertk.assertThat
+import assertk.assertions.isEmpty
+import com.jakewharton.diffuse.format.Arsc.Companion.toArsc
+import com.jakewharton.diffuse.io.Input.Companion.asInput
+import okio.ByteString
+import okio.ByteString.Companion.decodeHex
+import org.junit.Test
+
+class ArscTest {
+  @Test fun agp7EmptyResourceTable() {
+    val arsc = """
+      0200 0c00 2800 0000 0000 0000 0100 1c00
+      1c00 0000 0000 0000 0000 0000 0001 0000
+      1c00 0000 0000 0000
+    """.decodeHexWithWhitespace().asInput("resources.arsc").toArsc()
+
+    assertThat(arsc.configs).isEmpty()
+    assertThat(arsc.entries).isEmpty()
+  }
+
+  @Test fun agp4_2_2EmptyResourceTable() {
+    val arsc = """
+      0200 0c00 8001 0000 0100 0000 0100 1c00
+      1c00 0000 0000 0000 0000 0000 0001 0000
+      1c00 0000 0000 0000 0002 2001 5801 0000
+      7f00 0000 7200 6500 7400 7200 6f00 6600
+      6900 7400 3200 2e00 6100 6e00 6400 7200
+      6f00 6900 6400 2e00 7400 6500 7300 7400
+      0000 0000 0000 0000 0000 0000 0000 0000
+      0000 0000 0000 0000 0000 0000 0000 0000
+      0000 0000 0000 0000 0000 0000 0000 0000
+      0000 0000 0000 0000 0000 0000 0000 0000
+      0000 0000 0000 0000 0000 0000 0000 0000
+      0000 0000 0000 0000 0000 0000 0000 0000
+      0000 0000 0000 0000 0000 0000 0000 0000
+      0000 0000 0000 0000 0000 0000 0000 0000
+      0000 0000 0000 0000 0000 0000 0000 0000
+      0000 0000 0000 0000 0000 0000 0000 0000
+      0000 0000 0000 0000 0000 0000 0000 0000
+      0000 0000 0000 0000 0000 0000 0000 0000
+      0000 0000 0000 0000 0000 0000 0000 0000
+      0000 0000 2001 0000 0000 0000 3c01 0000
+      0000 0000 0000 0000 0100 1c00 1c00 0000
+      0000 0000 0000 0000 0000 0000 1c00 0000
+      0000 0000 0100 1c00 1c00 0000 0000 0000
+      0000 0000 0001 0000 1c00 0000 0000 0000                   
+    """.decodeHexWithWhitespace().asInput("resources.arsc").toArsc()
+
+    assertThat(arsc.configs).isEmpty()
+    assertThat(arsc.entries).isEmpty()
+  }
+
+  private fun String.decodeHexWithWhitespace(): ByteString {
+    return replace(Regex("\\s"), "").decodeHex()
+  }
+}


### PR DESCRIPTION
These are produced by AGP 7.x and newer when no resources are present, and currently fail when parsed with the binary-resources AGP library.

Closes #104