### PR TITLE
Add explicit Mordant dependency

### DIFF
--- a/diffuse/build.gradle
+++ b/diffuse/build.gradle
@@ -12,6 +12,7 @@ dependencies {
   implementation projects.formats
   implementation projects.reports
   implementation libs.clikt
+  implementation libs.mordant
 
   r8 libs.r8
 

--- a/diffuse/src/main/rules.txt
+++ b/diffuse/src/main/rules.txt
@@ -7,6 +7,13 @@
   public static void main(java.lang.String[]);
 }
 
+###############
+### Mordant ###
+###############
+
+-dontwarn org.graalvm.**
+-dontwarn com.oracle.svm.core.annotate.Delete
+
 ##############
 ### APKSIG ###
 ##############

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,6 +20,7 @@ asm = "org.ow2.asm:asm:9.6"
 diffUtils = "io.github.java-diff-utils:java-diff-utils:4.12"
 picnic = "com.jakewharton.picnic:picnic:0.7.0"
 r8 = "com.android.tools:r8:8.2.42"
+mordant = "com.github.ajalt.mordant:mordant:2.2.0"
 
 [plugins]
 dokka = "org.jetbrains.dokka:1.9.10"


### PR DESCRIPTION
This adds missing rules for JNA, but needs ones for Graal annotations until the next release. We also might want to use this for color output at some point.

Closes #227