### PR TITLE
Support diffing uses-permission counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 **Added**
 - Add `--summary-only` flag.
+- Support diffing uses-permission counts.
 
 **Fixed**
 - Significantly improve `.jar` diff performance.

--- a/formats/api/formats.api
+++ b/formats/api/formats.api
@@ -44,8 +44,9 @@ public final class com/jakewharton/diffuse/format/Aar$Companion {
 public final class com/jakewharton/diffuse/format/AndroidManifest {
 	public static final field Companion Lcom/jakewharton/diffuse/format/AndroidManifest$Companion;
 	public static final field NAME Ljava/lang/String;
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getPackageName ()Ljava/lang/String;
+	public final fun getUsesPermissionCount ()I
 	public final fun getVersionCode ()Ljava/lang/Long;
 	public final fun getVersionName ()Ljava/lang/String;
 	public final fun getXml ()Ljava/lang/String;

--- a/formats/src/main/kotlin/com/jakewharton/diffuse/format/AndroidManifest.kt
+++ b/formats/src/main/kotlin/com/jakewharton/diffuse/format/AndroidManifest.kt
@@ -37,6 +37,7 @@ private constructor(
   val packageName: String,
   val versionName: String?,
   val versionCode: Long?,
+  val usesPermissionCount: Int,
 ) {
   companion object {
     const val NAME = "AndroidManifest.xml"
@@ -176,8 +177,15 @@ private constructor(
         } else {
           null
         }
+      val usesPermissionCount = manifestElement.getElementsByTagName("uses-permission").length
 
-      return AndroidManifest(toFormattedXml(), packageName, versionName, versionCode)
+      return AndroidManifest(
+        toFormattedXml(),
+        packageName,
+        versionName,
+        versionCode,
+        usesPermissionCount,
+      )
     }
 
     private fun Document.toFormattedXml() = buildString {

--- a/reports/src/main/kotlin/com/jakewharton/diffuse/diff/ManifestDiff.kt
+++ b/reports/src/main/kotlin/com/jakewharton/diffuse/diff/ManifestDiff.kt
@@ -9,7 +9,8 @@ internal class ManifestDiff(val oldManifest: AndroidManifest, val newManifest: A
   internal val parsedPropertiesChanged =
     oldManifest.packageName != newManifest.packageName ||
       oldManifest.versionName != newManifest.versionName ||
-      oldManifest.versionCode != newManifest.versionCode
+      oldManifest.versionCode != newManifest.versionCode ||
+      oldManifest.usesPermissionCount != newManifest.usesPermissionCount
 
   val diff: List<String> = run {
     val oldLines = oldManifest.xml.lines()
@@ -36,6 +37,11 @@ internal fun ManifestDiff.toDetailReport() = buildString {
         row("package", oldManifest.packageName, newManifest.packageName)
         row("version code", oldManifest.versionCode, newManifest.versionCode)
         row("version name", oldManifest.versionName, newManifest.versionName)
+        row(
+          "uses-permission count",
+          oldManifest.usesPermissionCount,
+          newManifest.usesPermissionCount,
+        )
       }
     )
   }


### PR DESCRIPTION
There might be significant differences in blame attribution for AndroidManifest.xml. We usually pay close attention to changes in versionCode, targetSdk, and the count of uses-permissions. Adding an extra line to display the result.

```diff
OLD: before.apk (signature: V1, V2, V3)
NEW: after.apk (signature: V1, V2, V3)

          │          compressed           │          uncompressed
          ├───────────┬───────────┬───────┼───────────┬───────────┬────────
 APK      │ old       │ new       │ diff  │ old       │ new       │ diff
──────────┼───────────┼───────────┼───────┼───────────┼───────────┼────────
      dex │   1.7 MiB │   1.7 MiB │   0 B │   3.8 MiB │   3.8 MiB │    0 B
     arsc │ 372.3 KiB │ 372.3 KiB │   0 B │ 372.2 KiB │ 372.2 KiB │    0 B
 manifest │   2.8 KiB │   2.8 KiB │ -30 B │  11.2 KiB │    11 KiB │ -176 B
      res │ 266.9 KiB │ 266.9 KiB │  -4 B │ 380.9 KiB │ 380.9 KiB │    0 B
    asset │   6.1 KiB │   6.1 KiB │   0 B │   5.9 KiB │   5.9 KiB │    0 B
    other │  28.9 KiB │  28.9 KiB │   0 B │  58.9 KiB │  58.9 KiB │    0 B
──────────┼───────────┼───────────┼───────┼───────────┼───────────┼────────
    total │   2.4 MiB │   2.4 MiB │ -34 B │   4.6 MiB │   4.6 MiB │ -176 B

 DEX     │ old   │ new   │ diff
─────────┼───────┼───────┼───────────
   files │     1 │     1 │ 0
 strings │ 25213 │ 25213 │ 0 (+0 -0)
   types │  5662 │  5662 │ 0 (+0 -0)
 classes │  4444 │  4444 │ 0 (+0 -0)
 methods │ 25556 │ 25556 │ 0 (+0 -0)
  fields │ 28471 │ 28471 │ 0 (+0 -0)

 ARSC    │ old  │ new  │ diff
─────────┼──────┼──────┼──────
 configs │   49 │   49 │  0
 entries │ 2416 │ 2416 │  0

=================
====   APK   ====
=================

    compressed    │   uncompressed    │
──────────┬───────┼──────────┬────────┤
 size     │ diff  │ size     │ diff   │ path
──────────┼───────┼──────────┼────────┼────────────────────────
  2.8 KiB │ -30 B │   11 KiB │ -176 B │ ∆ AndroidManifest.xml
  2.4 KiB │  -4 B │  2.3 KiB │    0 B │ ∆ res/1I.9.png
  1.2 KiB │  +1 B │  1.3 KiB │    0 B │ ∆ META-INF/CERT.RSA
   13 KiB │  -1 B │ 28.3 KiB │    0 B │ ∆ META-INF/MANIFEST.MF
──────────┼───────┼──────────┼────────┼────────────────────────
 19.3 KiB │ -34 B │ 42.9 KiB │ -176 B │ (total)


======================
====   MANIFEST   ====
======================

                       │ old                    │ new
───────────────────────┼────────────────────────┼────────────────────────
 package               │ io.goooler.demoapp.app │ io.goooler.demoapp.app
 version code          │ 109000                 │ 109000
 version name          │ 1.9.0                  │ 1.9.0
 uses-permission count │ 14                     │ 13

@@ -18,5 +18,2 @@
   <uses-permission
-      android:name="android.permission.MOUNT_UNMOUNT_FILESYSTEM"
-      />
-  <uses-permission
       android:name="android.permission.ACCESS_NETWORK_STATE"
```