### PR TITLE
Fix error when handing mapping files that are over 2^30 in size

### DIFF
--- a/formats/src/main/kotlin/com/jakewharton/diffuse/format/ApiMapping.kt
+++ b/formats/src/main/kotlin/com/jakewharton/diffuse/format/ApiMapping.kt
@@ -81,7 +81,7 @@ class ApiMapping private constructor(private val typeMappings: Map<TypeDescripto
       var toDescriptor: TypeDescriptor? = null
       var fields: MutableMap<String, String>? = null
       var methods: MutableMap<MethodSignature, String>? = null
-      source().use { bufferedSource -> 
+      source().use { bufferedSource ->
         generateSequence { bufferedSource.readUtf8Line() }.forEachIndexed { index, line ->
           if (line.trimStart().startsWith('#') || line.isBlank()) {
             return@forEachIndexed

--- a/formats/src/main/kotlin/com/jakewharton/diffuse/format/ApiMapping.kt
+++ b/formats/src/main/kotlin/com/jakewharton/diffuse/format/ApiMapping.kt
@@ -81,46 +81,48 @@ class ApiMapping private constructor(private val typeMappings: Map<TypeDescripto
       var toDescriptor: TypeDescriptor? = null
       var fields: MutableMap<String, String>? = null
       var methods: MutableMap<MethodSignature, String>? = null
-      toUtf8().split('\n').forEachIndexed { index, line ->
-        if (line.trimStart().startsWith('#') || line.isBlank()) {
-          return@forEachIndexed
-        }
-        if (line.startsWith(' ')) {
-          val result = memberLine.matchEntire(line)
-            ?: throw IllegalArgumentException(
-              "Unable to parse line ${index + 1} as member mapping: $line",
-            )
-          val (_, returnType, fromName, parameters, toName) = result.groupValues
+      source().use { bufferedSource -> 
+        generateSequence { bufferedSource.readUtf8Line() }.forEachIndexed { index, line ->
+          if (line.trimStart().startsWith('#') || line.isBlank()) {
+            return@forEachIndexed
+          }
+          if (line.startsWith(' ')) {
+            val result = memberLine.matchEntire(line)
+              ?: throw IllegalArgumentException(
+                "Unable to parse line ${index + 1} as member mapping: $line",
+              )
+            val (_, returnType, fromName, parameters, toName) = result.groupValues
 
-          if (parameters != "") {
-            val returnDescriptor = humanNameToDescriptor(returnType)
-            val parameterDescriptors = parameters
-              .substring(1, parameters.lastIndex) // Remove leading '(' and trailing ')'.
-              .takeUnless(String::isEmpty) // Do not process parameter-less methods.
-              ?.split(',')
-              ?.map(Companion::humanNameToDescriptor)
-              ?: emptyList()
+            if (parameters != "") {
+              val returnDescriptor = humanNameToDescriptor(returnType)
+              val parameterDescriptors = parameters
+                .substring(1, parameters.lastIndex) // Remove leading '(' and trailing ')'.
+                .takeUnless(String::isEmpty) // Do not process parameter-less methods.
+                ?.split(',')
+                ?.map(Companion::humanNameToDescriptor)
+                ?: emptyList()
 
-            val lookupSignature = MethodSignature(returnDescriptor, toName, parameterDescriptors)
-            methods!![lookupSignature] = fromName
+              val lookupSignature = MethodSignature(returnDescriptor, toName, parameterDescriptors)
+              methods!![lookupSignature] = fromName
+            } else {
+              fields!![toName] = fromName
+            }
           } else {
-            fields!![toName] = fromName
-          }
-        } else {
-          if (fromDescriptor != null) {
-            typeMappings[toDescriptor!!] = TypeMapping(fromDescriptor!!, fields!!, methods!!)
-          }
+            if (fromDescriptor != null) {
+              typeMappings[toDescriptor!!] = TypeMapping(fromDescriptor!!, fields!!, methods!!)
+            }
 
-          val result = typeLine.matchEntire(line)
-            ?: throw IllegalArgumentException(
-              "Unable to parse line ${index + 1} as type mapping: $line",
-            )
-          val (_, fromType, toType) = result.groupValues
+            val result = typeLine.matchEntire(line)
+              ?: throw IllegalArgumentException(
+                "Unable to parse line ${index + 1} as type mapping: $line",
+              )
+            val (_, fromType, toType) = result.groupValues
 
-          fromDescriptor = humanNameToDescriptor(fromType)
-          toDescriptor = humanNameToDescriptor(toType)
-          fields = mutableMapOf()
-          methods = mutableMapOf()
+            fromDescriptor = humanNameToDescriptor(fromType)
+            toDescriptor = humanNameToDescriptor(toType)
+            fields = mutableMapOf()
+            methods = mutableMapOf()
+          }
         }
       }
       if (fromDescriptor != null) {


### PR DESCRIPTION
Use a `Sequence` to read the mapping file line by line instead of calling `toUtf8()` on the whole file as that will not work if the string size is over 2^30.

e.g. we saw this error without this change:

```
java.lang.OutOfMemoryError: UTF16 String size is 1088339595, should be less than 1073741823
	at java.base/java.lang.StringUTF16.newBytesFor(StringUTF16.java:50)
	at java.base/java.lang.String.<init>(String.java:595)
	at java.base/java.lang.String.<init>(String.java:1443)
	at okio.Buffer.readString(Buffer.kt:315)
	at okio.Buffer.readUtf8(Buffer.kt:299)
	at okio.RealBufferedSource.readUtf8(RealBufferedSource.kt:306)
	at com.jakewharton.diffuse.io.Input$DefaultImpls.toUtf8(Input.kt:18)
	at com.jakewharton.diffuse.io.PathInput.toUtf8(Input.kt:37)
	at com.jakewharton.diffuse.format.ApiMapping$Companion.parse(ApiMapping.kt:84)
	at com.jakewharton.diffuse.format.Aab$Companion.parse(Aab.kt:52)

```