### PR TITLE
Improve JAR parsing performance

### DIFF
--- a/formats/src/main/kotlin/com/jakewharton/diffuse/format/Jar.kt
+++ b/formats/src/main/kotlin/com/jakewharton/diffuse/format/Jar.kt
@@ -25,7 +25,7 @@ private constructor(
         val classes =
           zip.entries.filter { it.path.endsWith(".class") }.map { it.asInput().toClass() }
 
-        val declaredMembers = classes.flatMap { it.declaredMembers }
+        val declaredMembers = classes.flatMapTo(LinkedHashSet()) { it.declaredMembers }
         val referencedMembers = classes.flatMapTo(LinkedHashSet()) { it.referencedMembers }
         // Declared methods are likely to reference other declared members. Ensure all are removed.
         referencedMembers -= declaredMembers


### PR DESCRIPTION
When using `diff --jar` on large JARs (~500 000 members) the process would take hours to finish.


`referencedMembers -= declaredMembers` is where all the time was spent.
This actually does `AbstractSet#removeAll()` which calls `declaredMembers.contains()` for each element of `referencedMembers`. `List.contains()` is O(n) vs O(1) for `Set.contains()`, so the whole operation would be O(n^2) instead of O(n).