### PR TITLE
Add --summary-only flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## [Unreleased]
 [Unreleased]: https://github.com/JakeWharton/diffuse/compare/0.3.0...HEAD
-
+**Added**
+- Add `--summary-only` flag.
 
 ## [0.3.0] - 2024-02-20
 [0.3.0]: https://github.com/JakeWharton/diffuse/releases/tag/0.3.0

--- a/diffuse/src/main/kotlin/com/jakewharton/diffuse/diffuse.kt
+++ b/diffuse/src/main/kotlin/com/jakewharton/diffuse/diffuse.kt
@@ -127,9 +127,16 @@ private class OutputOptions(outputFs: FileSystem, private val output: PrintStrea
         }
       }
 
+  private val summaryOnly by
+    option(
+        "--summary-only",
+        help = "Skip generating detailed reports, outputting only the summary.",
+      )
+      .flag()
+
   fun write(reportFactory: Report.Factory) {
-    val textReport by lazy(NONE) { reportFactory.toTextReport().toString() }
-    val htmlReport by lazy(NONE) { reportFactory.toHtmlReport().toString() }
+    val textReport by lazy(NONE) { reportFactory.toTextReport(summaryOnly).toString() }
+    val htmlReport by lazy(NONE) { reportFactory.toHtmlReport(summaryOnly).toString() }
 
     text?.writeText(textReport)
     html?.writeText(htmlReport)

--- a/reports/src/main/kotlin/com/jakewharton/diffuse/diff/AabDiff.kt
+++ b/reports/src/main/kotlin/com/jakewharton/diffuse/diff/AabDiff.kt
@@ -29,5 +29,5 @@ internal class AabDiff(val oldAab: Aab, val newAab: Aab) : BinaryDiff {
         ModuleDiff(oldModule, newAab.featureModules.getValue(name))
       }
 
-  override fun toTextReport(): Report = AabDiffTextReport(this)
+  override fun toTextReport(summaryOnly: Boolean): Report = AabDiffTextReport(this, summaryOnly)
 }

--- a/reports/src/main/kotlin/com/jakewharton/diffuse/diff/AarDiff.kt
+++ b/reports/src/main/kotlin/com/jakewharton/diffuse/diff/AarDiff.kt
@@ -15,5 +15,5 @@ internal class AarDiff(
   val jars = JarsDiff(oldAar.jars, oldMapping, newAar.jars, newMapping)
   val manifest = ManifestDiff(oldAar.manifest, newAar.manifest)
 
-  override fun toTextReport(): Report = AarDiffTextReport(this)
+  override fun toTextReport(summaryOnly: Boolean): Report = AarDiffTextReport(this, summaryOnly)
 }

--- a/reports/src/main/kotlin/com/jakewharton/diffuse/diff/ApkDiff.kt
+++ b/reports/src/main/kotlin/com/jakewharton/diffuse/diff/ApkDiff.kt
@@ -24,5 +24,5 @@ internal class ApkDiff(
 
   val lintMessages = listOfNotNull(archive.resourcesArscCompression())
 
-  override fun toTextReport(): Report = ApkDiffTextReport(this)
+  override fun toTextReport(summaryOnly: Boolean): Report = ApkDiffTextReport(this, summaryOnly)
 }

--- a/reports/src/main/kotlin/com/jakewharton/diffuse/diff/DexDiff.kt
+++ b/reports/src/main/kotlin/com/jakewharton/diffuse/diff/DexDiff.kt
@@ -32,7 +32,7 @@ internal class DexDiff(val oldDexes: List<Dex>, val newDexes: List<Dex>) : Binar
 
   val changed = strings.changed || types.changed || methods.changed || fields.changed
 
-  override fun toTextReport(): Report = DexDiffTextReport(this)
+  override fun toTextReport(summaryOnly: Boolean): Report = DexDiffTextReport(this, summaryOnly)
 }
 
 internal fun DexDiff.toSummaryTable() =

--- a/reports/src/main/kotlin/com/jakewharton/diffuse/diff/JarDiff.kt
+++ b/reports/src/main/kotlin/com/jakewharton/diffuse/diff/JarDiff.kt
@@ -16,5 +16,5 @@ internal class JarDiff(
 
   val changed = jars.changed || archive.changed
 
-  override fun toTextReport(): Report = JarDiffTextReport(this)
+  override fun toTextReport(summaryOnly: Boolean): Report = JarDiffTextReport(this, summaryOnly)
 }

--- a/reports/src/main/kotlin/com/jakewharton/diffuse/info/AabInfo.kt
+++ b/reports/src/main/kotlin/com/jakewharton/diffuse/info/AabInfo.kt
@@ -6,7 +6,7 @@ import com.jakewharton.diffuse.report.Report
 import com.jakewharton.diffuse.report.text.AabInfoTextReport
 
 class AabInfo(private val aab: Aab) : BinaryDiff {
-  override fun toTextReport(): Report {
+  override fun toTextReport(summaryOnly: Boolean): Report {
     return AabInfoTextReport(aab)
   }
 }

--- a/reports/src/main/kotlin/com/jakewharton/diffuse/info/AarInfo.kt
+++ b/reports/src/main/kotlin/com/jakewharton/diffuse/info/AarInfo.kt
@@ -5,7 +5,7 @@ import com.jakewharton.diffuse.report.Report
 import com.jakewharton.diffuse.report.text.AarInfoTextReport
 
 class AarInfo(private val aar: Aar) : BinaryInfo {
-  override fun toTextReport(): Report {
+  override fun toTextReport(summaryOnly: Boolean): Report {
     return AarInfoTextReport(aar)
   }
 }

--- a/reports/src/main/kotlin/com/jakewharton/diffuse/info/ApkInfo.kt
+++ b/reports/src/main/kotlin/com/jakewharton/diffuse/info/ApkInfo.kt
@@ -5,7 +5,7 @@ import com.jakewharton.diffuse.report.Report
 import com.jakewharton.diffuse.report.text.ApkInfoTextReport
 
 class ApkInfo(private val apk: Apk) : BinaryInfo {
-  override fun toTextReport(): Report {
+  override fun toTextReport(summaryOnly: Boolean): Report {
     return ApkInfoTextReport(apk)
   }
 }

--- a/reports/src/main/kotlin/com/jakewharton/diffuse/info/DexInfo.kt
+++ b/reports/src/main/kotlin/com/jakewharton/diffuse/info/DexInfo.kt
@@ -5,7 +5,7 @@ import com.jakewharton.diffuse.report.Report
 import com.jakewharton.diffuse.report.text.DexInfoTextReport
 
 class DexInfo(private val dex: Dex) : BinaryInfo {
-  override fun toTextReport(): Report {
+  override fun toTextReport(summaryOnly: Boolean): Report {
     return DexInfoTextReport(dex)
   }
 }

--- a/reports/src/main/kotlin/com/jakewharton/diffuse/info/JarInfo.kt
+++ b/reports/src/main/kotlin/com/jakewharton/diffuse/info/JarInfo.kt
@@ -5,7 +5,7 @@ import com.jakewharton.diffuse.report.Report
 import com.jakewharton.diffuse.report.text.JarInfoTextReport
 
 class JarInfo(private val jar: Jar) : BinaryInfo {
-  override fun toTextReport(): Report {
+  override fun toTextReport(summaryOnly: Boolean): Report {
     return JarInfoTextReport(jar)
   }
 }

--- a/reports/src/main/kotlin/com/jakewharton/diffuse/report/Report.kt
+++ b/reports/src/main/kotlin/com/jakewharton/diffuse/report/Report.kt
@@ -4,9 +4,9 @@ interface Report {
   fun write(appendable: Appendable)
 
   interface Factory {
-    fun toTextReport(): Report
+    fun toTextReport(summaryOnly: Boolean): Report
 
-    fun toHtmlReport(): Report {
+    fun toHtmlReport(summaryOnly: Boolean): Report {
       TODO("Implement HTML reporting")
     }
   }

--- a/reports/src/main/kotlin/com/jakewharton/diffuse/report/text/AabDiffTextReport.kt
+++ b/reports/src/main/kotlin/com/jakewharton/diffuse/report/text/AabDiffTextReport.kt
@@ -8,7 +8,8 @@ import com.jakewharton.picnic.TextAlignment.BottomLeft
 import com.jakewharton.picnic.TextAlignment.MiddleCenter
 import com.jakewharton.picnic.TextAlignment.MiddleRight
 
-internal class AabDiffTextReport(private val aabDiff: AabDiff) : Report {
+internal class AabDiffTextReport(private val aabDiff: AabDiff, private val summaryOnly: Boolean) :
+  Report {
   override fun write(appendable: Appendable) {
     appendable.apply {
       append("OLD: ")
@@ -48,6 +49,7 @@ internal class AabDiffTextReport(private val aabDiff: AabDiff) : Report {
           .toString()
       )
 
+      if (summaryOnly) return@apply
       appendLine("==================")
       appendLine("====   base   ====")
       appendLine("==================")

--- a/reports/src/main/kotlin/com/jakewharton/diffuse/report/text/AarDiffTextReport.kt
+++ b/reports/src/main/kotlin/com/jakewharton/diffuse/report/text/AarDiffTextReport.kt
@@ -6,7 +6,8 @@ import com.jakewharton.diffuse.diff.toSummaryTable
 import com.jakewharton.diffuse.format.ArchiveFile.Type
 import com.jakewharton.diffuse.report.Report
 
-internal class AarDiffTextReport(private val aarDiff: AarDiff) : Report {
+internal class AarDiffTextReport(private val aarDiff: AarDiff, private val summaryOnly: Boolean) :
+  Report {
   override fun write(appendable: Appendable) {
     appendable.apply {
       append("OLD: ")
@@ -25,6 +26,8 @@ internal class AarDiffTextReport(private val aarDiff: AarDiff) : Report {
       )
       appendLine()
       appendLine(aarDiff.jars.toSummaryTable("JAR"))
+
+      if (summaryOnly) return@apply
       if (aarDiff.archive.changed) {
         appendLine()
         appendLine("=================")

--- a/reports/src/main/kotlin/com/jakewharton/diffuse/report/text/ApkDiffTextReport.kt
+++ b/reports/src/main/kotlin/com/jakewharton/diffuse/report/text/ApkDiffTextReport.kt
@@ -9,7 +9,8 @@ import com.jakewharton.diffuse.format.ArchiveFile.Type
 import com.jakewharton.diffuse.report.Report
 import com.jakewharton.diffuse.report.toSummaryString
 
-internal class ApkDiffTextReport(private val apkDiff: ApkDiff) : Report {
+internal class ApkDiffTextReport(private val apkDiff: ApkDiff, private val summaryOnly: Boolean) :
+  Report {
   override fun write(appendable: Appendable) {
     appendable.apply {
       append("OLD: ")
@@ -58,6 +59,8 @@ internal class ApkDiffTextReport(private val apkDiff: ApkDiff) : Report {
       appendLine(apkDiff.dex.toSummaryTable())
       appendLine()
       appendLine(apkDiff.arsc.toSummaryTable())
+
+      if (summaryOnly) return@apply
       if (apkDiff.archive.changed || apkDiff.signatures.changed) {
         appendLine()
         appendLine("=================")

--- a/reports/src/main/kotlin/com/jakewharton/diffuse/report/text/DexDiffTextReport.kt
+++ b/reports/src/main/kotlin/com/jakewharton/diffuse/report/text/DexDiffTextReport.kt
@@ -4,7 +4,8 @@ import com.jakewharton.diffuse.diff.DexDiff
 import com.jakewharton.diffuse.diff.toDetailReport
 import com.jakewharton.diffuse.report.Report
 
-internal class DexDiffTextReport(private val dexDiff: DexDiff) : Report {
+internal class DexDiffTextReport(private val dexDiff: DexDiff, private val summaryOnly: Boolean) :
+  Report {
   private val oldDex =
     requireNotNull(dexDiff.oldDexes.singleOrNull()) {
       "Dex diff report only supports a single old dex. Found: ${dexDiff.oldDexes}"
@@ -21,6 +22,8 @@ internal class DexDiffTextReport(private val dexDiff: DexDiff) : Report {
       append("NEW: ")
       appendLine(newDex.filename)
       appendLine()
+
+      if (summaryOnly) return@apply
       appendLine(dexDiff.toDetailReport())
     }
   }

--- a/reports/src/main/kotlin/com/jakewharton/diffuse/report/text/JarDiffTextReport.kt
+++ b/reports/src/main/kotlin/com/jakewharton/diffuse/report/text/JarDiffTextReport.kt
@@ -6,7 +6,8 @@ import com.jakewharton.diffuse.diff.toSummaryTable
 import com.jakewharton.diffuse.format.ArchiveFile.Type
 import com.jakewharton.diffuse.report.Report
 
-internal class JarDiffTextReport(private val jarDiff: JarDiff) : Report {
+internal class JarDiffTextReport(private val jarDiff: JarDiff, private val summaryOnly: Boolean) :
+  Report {
   override fun write(appendable: Appendable) {
     appendable.apply {
       append("OLD: ")
@@ -19,6 +20,8 @@ internal class JarDiffTextReport(private val jarDiff: JarDiff) : Report {
       appendLine(jarDiff.archive.toSummaryTable("JAR", Type.JAR_TYPES))
       appendLine()
       appendLine(jarDiff.jars.toSummaryTable("CLASSES"))
+
+      if (summaryOnly) return@apply
       if (jarDiff.archive.changed) {
         appendLine()
         appendLine("=================")


### PR DESCRIPTION
<details><summary>Tested it manually.</summary>
<p>

```
./diffuse diff --summary-only /Users/goooler/Downloads/Lawnicons.2.17.0.apk /Users/goooler/Downloads/Lawnicons.2.17.1.apk
OLD: Lawnicons.2.17.0.apk (signature: V2)
NEW: Lawnicons.2.17.1.apk (signature: V2)

          │            compressed             │            uncompressed            
          ├───────────┬───────────┬───────────┼───────────┬───────────┬────────────
 APK      │ old       │ new       │ diff      │ old       │ new       │ diff       
──────────┼───────────┼───────────┼───────────┼───────────┼───────────┼────────────
      dex │   1.6 MiB │   1.6 MiB │    +171 B │   3.2 MiB │   3.2 MiB │     +760 B 
     arsc │   1.8 MiB │   1.8 MiB │  +8.1 KiB │   1.8 MiB │   1.8 MiB │   +8.1 KiB 
 manifest │   3.6 KiB │   3.6 KiB │      -1 B │    16 KiB │    16 KiB │        0 B 
      res │  10.2 MiB │  10.2 MiB │ +69.6 KiB │  24.2 MiB │  24.4 MiB │ +161.5 KiB 
   native │ 104.7 KiB │ 106.4 KiB │  +1.7 KiB │  36.5 KiB │  36.5 KiB │        0 B 
    asset │  51.8 KiB │  50.8 KiB │    -1 KiB │ 216.9 KiB │ 215.9 KiB │     -1 KiB 
    other │  46.9 KiB │  46.9 KiB │      -1 B │ 104.4 KiB │ 104.4 KiB │        0 B 
──────────┼───────────┼───────────┼───────────┼───────────┼───────────┼────────────
    total │  13.8 MiB │  13.9 MiB │ +78.5 KiB │  29.7 MiB │  29.8 MiB │ +169.3 KiB 

 DEX     │ old   │ new   │ diff             
─────────┼───────┼───────┼──────────────────
   files │     1 │     1 │  0               
 strings │ 14634 │ 14634 │  0 (+17 -17)     
   types │  5021 │  5020 │ -1 (+10 -11)     
 classes │  4122 │  4121 │ -1 (+3 -4)       
 methods │ 20965 │ 20968 │ +3 (+887 -884)   
  fields │ 14270 │ 14266 │ -4 (+1119 -1123) 

 ARSC    │ old   │ new   │ diff           
─────────┼───────┼───────┼────────────────
 configs │   148 │   148 │    0           
 entries │ 17224 │ 17340 │ +116 (+116 -0) 
```

</p>
</details> 

Closes #466.