### PR TITLE
Support diffing bytecode versions for classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 **Added**
 - Add `--summary-only` flag.
+- Support diffing bytecode versions for classes.
 
 **Fixed**
 - Significantly improve `.jar` diff performance.

--- a/formats/api/formats.api
+++ b/formats/api/formats.api
@@ -234,8 +234,9 @@ public abstract interface class com/jakewharton/diffuse/format/BinaryFormat {
 
 public final class com/jakewharton/diffuse/format/Class {
 	public static final field Companion Lcom/jakewharton/diffuse/format/Class$Companion;
-	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;ILjava/util/List;Ljava/util/List;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBytecodeVersion ()I
 	public final fun getDeclaredMembers ()Ljava/util/List;
 	public final fun getDescriptor-BeHrSHk ()Ljava/lang/String;
 	public final fun getReferencedMembers ()Ljava/util/List;

--- a/formats/src/main/kotlin/com/jakewharton/diffuse/format/Class.kt
+++ b/formats/src/main/kotlin/com/jakewharton/diffuse/format/Class.kt
@@ -12,16 +12,19 @@ import org.objectweb.asm.Opcodes
 class Class
 private constructor(
   val descriptor: TypeDescriptor,
+  val bytecodeVersion: Int,
   val declaredMembers: List<Member>,
   val referencedMembers: List<Member>,
 ) {
   override fun toString() = descriptor.toString()
 
-  override fun hashCode() = Objects.hash(descriptor, declaredMembers, referencedMembers)
+  override fun hashCode() =
+    Objects.hash(descriptor, bytecodeVersion, declaredMembers, referencedMembers)
 
   override fun equals(other: Any?) =
     other is Class &&
       descriptor == other.descriptor &&
+      bytecodeVersion == other.bytecodeVersion &&
       declaredMembers == other.declaredMembers &&
       referencedMembers == other.referencedMembers
 
@@ -36,14 +39,32 @@ private constructor(
       val declaredVisitor = DeclaredMembersVisitor(type, referencedVisitor)
       reader.accept(declaredVisitor, 0)
 
-      return Class(type, declaredVisitor.members.sorted(), referencedVisitor.members.sorted())
+      return Class(
+        type,
+        declaredVisitor.version,
+        declaredVisitor.members.sorted(),
+        referencedVisitor.members.sorted(),
+      )
     }
   }
 }
 
 private class DeclaredMembersVisitor(val type: TypeDescriptor, val methodVisitor: MethodVisitor) :
   ClassVisitor(Opcodes.ASM9) {
+  var version: Int = 0
   val members = mutableListOf<Member>()
+
+  override fun visit(
+    version: Int,
+    access: Int,
+    name: String,
+    signature: String?,
+    superName: String?,
+    interfaces: Array<out String>?,
+  ) {
+    this.version = version
+    super.visit(version, access, name, signature, superName, interfaces)
+  }
 
   override fun visitMethod(
     access: Int,

--- a/reports/src/main/kotlin/com/jakewharton/diffuse/diff/JarsDiff.kt
+++ b/reports/src/main/kotlin/com/jakewharton/diffuse/diff/JarsDiff.kt
@@ -18,6 +18,10 @@ internal class JarsDiff(
   val newMapping: ApiMapping,
 ) {
   val classes = componentDiff(oldJars, newJars) { it.classes.map(Class::descriptor) }
+  val bytecodeVersions =
+    componentDiff(oldJars, newJars) { jar ->
+      jar.classes.map { "${it.descriptor}: ${it.bytecodeVersion}" }
+    }
   val methods = componentDiff(oldJars, newJars) { it.members.filterIsInstance<Method>() }
   val declaredMethods =
     componentDiff(oldJars, newJars) { it.declaredMembers.filterIsInstance<Method>() }
@@ -29,7 +33,7 @@ internal class JarsDiff(
   val referencedFields =
     componentDiff(oldJars, newJars) { it.referencedMembers.filterIsInstance<Field>() }
 
-  val changed = methods.changed || fields.changed
+  val changed = bytecodeVersions.changed || methods.changed || fields.changed
 }
 
 internal fun JarsDiff.toSummaryTable(name: String) =
@@ -72,6 +76,7 @@ internal fun JarsDiff.toSummaryTable(name: String) =
 internal fun JarsDiff.toDetailReport() = buildString {
   // TODO appendComponentDiff("STRINGS", strings)?
   appendComponentDiff("CLASSES", classes)
+  appendComponentDiff("BYTECODE VERSIONS", bytecodeVersions)
   appendComponentDiff("METHODS", methods)
   appendComponentDiff("FIELDS", fields)
 }


### PR DESCRIPTION
```
OLD: old.jar
NEW: new.jar

 JAR   │ old     │ new     │ diff
───────┼─────────┼─────────┼────────
 class │ 1.2 KiB │ 1.4 KiB │ +201 B
 other │    72 B │    72 B │    0 B
───────┼─────────┼─────────┼────────
 total │ 1.3 KiB │ 1.5 KiB │ +201 B

 CLASSES │ old │ new │ diff
─────────┼─────┼─────┼───────────
 classes │   1 │   1 │ 0 (+0 -0)
 methods │   4 │   4 │ 0 (+1 -1)
  fields │   1 │   1 │ 0 (+0 -0)

=================
====   JAR   ====
=================

 size    │ diff   │ path
─────────┼────────┼────────────────────────────
 1.4 KiB │ +201 B │ ∆ org/example/MainKt.class
─────────┼────────┼────────────────────────────
 1.4 KiB │ +201 B │ (total)

=====================
====   CLASSES   ====
=====================

BYTECODE VERSIONS:

   old │ new │ diff
  ─────┼─────┼───────────
   1   │ 1   │ 0 (+1 -1)

  + org.example.MainKt: 65

  - org.example.MainKt: 69

METHODS:

   old │ new │ diff
  ─────┼─────┼───────────
   4   │ 4   │ 0 (+1 -1)

  + kotlin.jvm.internal.Intrinsics checkNotNullParameter(Object, String)

  - org.example.MainKt main()
```