### PR TITLE
Add --byte-unit option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 **Added**
 - Add `--summary-only` flag.
+- Add `--byte-unit` option.
 
 **Fixed**
 - Significantly improve `.jar` diff performance.

--- a/diffuse/src/main/kotlin/com/jakewharton/diffuse/diffuse.kt
+++ b/diffuse/src/main/kotlin/com/jakewharton/diffuse/diffuse.kt
@@ -39,6 +39,7 @@ import com.jakewharton.diffuse.info.AarInfo
 import com.jakewharton.diffuse.info.ApkInfo
 import com.jakewharton.diffuse.info.DexInfo
 import com.jakewharton.diffuse.info.JarInfo
+import com.jakewharton.diffuse.io.ByteUnit
 import com.jakewharton.diffuse.io.Input
 import com.jakewharton.diffuse.io.Input.Companion.asInput
 import com.jakewharton.diffuse.report.Report
@@ -134,9 +135,14 @@ private class OutputOptions(outputFs: FileSystem, private val output: PrintStrea
       )
       .flag()
 
+  private val byteUnit by
+    option("--byte-unit", help = "Byte unit to use in reports. Default is 'binary'.")
+      .choice("binary" to ByteUnit.Binary, "decimal" to ByteUnit.Decimal)
+      .default(ByteUnit.Binary)
+
   fun write(reportFactory: Report.Factory) {
-    val textReport by lazy(NONE) { reportFactory.toTextReport(summaryOnly).toString() }
-    val htmlReport by lazy(NONE) { reportFactory.toHtmlReport(summaryOnly).toString() }
+    val textReport by lazy(NONE) { reportFactory.toTextReport(summaryOnly, byteUnit).toString() }
+    val htmlReport by lazy(NONE) { reportFactory.toHtmlReport(summaryOnly, byteUnit).toString() }
 
     text?.writeText(textReport)
     html?.writeText(htmlReport)

--- a/io/api/io.api
+++ b/io/api/io.api
@@ -1,3 +1,11 @@
+public final class com/jakewharton/diffuse/io/ByteUnit : java/lang/Enum {
+	public static final field Binary Lcom/jakewharton/diffuse/io/ByteUnit;
+	public static final field Decimal Lcom/jakewharton/diffuse/io/ByteUnit;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/jakewharton/diffuse/io/ByteUnit;
+	public static fun values ()[Lcom/jakewharton/diffuse/io/ByteUnit;
+}
+
 public final class com/jakewharton/diffuse/io/BytesInput : com/jakewharton/diffuse/io/Input {
 	public final fun getBytes ()Lokio/ByteString;
 	public fun getName ()Ljava/lang/String;
@@ -62,6 +70,8 @@ public final class com/jakewharton/diffuse/io/Size : java/lang/Comparable {
 	public static final fun plus-2SwpbTA (JJ)J
 	public fun toString ()Ljava/lang/String;
 	public static fun toString-impl (J)Ljava/lang/String;
+	public static final fun toString-impl (JLcom/jakewharton/diffuse/io/ByteUnit;)Ljava/lang/String;
+	public static synthetic fun toString-impl$default (JLcom/jakewharton/diffuse/io/ByteUnit;ILjava/lang/Object;)Ljava/lang/String;
 	public static final fun unaryMinus-kab5oJg (J)J
 	public final synthetic fun unbox-impl ()J
 }

--- a/io/src/main/kotlin/com/jakewharton/diffuse/io/Size.kt
+++ b/io/src/main/kotlin/com/jakewharton/diffuse/io/Size.kt
@@ -2,15 +2,22 @@ package com.jakewharton.diffuse.io
 
 import kotlin.math.absoluteValue
 import me.saket.bytesize.binaryBytes
+import me.saket.bytesize.decimalBytes
+
+enum class ByteUnit {
+  Binary,
+  Decimal,
+}
 
 @JvmInline
 value class Size(val bytes: Long) : Comparable<Size> {
-  override fun toString(): String =
-    if (bytes >= 0) {
-      bytes.binaryBytes.toString()
-    } else {
-      "-" + (-bytes).binaryBytes.toString()
-    }
+  override fun toString(): String = toString(ByteUnit.Binary)
+
+  fun toString(format: ByteUnit = ByteUnit.Binary): String =
+    when (format) {
+      ByteUnit.Binary -> bytes.binaryBytes
+      ByteUnit.Decimal -> bytes.decimalBytes
+    }.toString()
 
   override fun compareTo(other: Size) = bytes.compareTo(other.bytes)
 

--- a/io/src/test/kotlin/com/jakewharton/diffuse/io/SizeTest.kt
+++ b/io/src/test/kotlin/com/jakewharton/diffuse/io/SizeTest.kt
@@ -2,6 +2,7 @@ package com.jakewharton.diffuse.io
 
 import assertk.assertThat
 import assertk.assertions.hasToString
+import assertk.assertions.isEqualTo
 import org.junit.Test
 
 class SizeTest {
@@ -16,5 +17,18 @@ class SizeTest {
     assertThat(Size(-(1024L * 1024))).hasToString("-1 MiB")
     assertThat(Size(1024L * 1024 * 1024)).hasToString("1 GiB")
     assertThat(Size(-(1024L * 1024 * 1024))).hasToString("-1 GiB")
+  }
+
+  @Test
+  fun toStringDecimalFormatsBytes() {
+    assertThat(Size(0).toString(ByteUnit.Decimal)).isEqualTo("0 B")
+    assertThat(Size(1).toString(ByteUnit.Decimal)).isEqualTo("1 B")
+    assertThat(Size(-1).toString(ByteUnit.Decimal)).isEqualTo("-1 B")
+    assertThat(Size(1000).toString(ByteUnit.Decimal)).isEqualTo("1 KB")
+    assertThat(Size(-1000).toString(ByteUnit.Decimal)).isEqualTo("-1 KB")
+    assertThat(Size(1000L * 1000).toString(ByteUnit.Decimal)).isEqualTo("1 MB")
+    assertThat(Size(-(1000L * 1000)).toString(ByteUnit.Decimal)).isEqualTo("-1 MB")
+    assertThat(Size(1000L * 1000 * 1000).toString(ByteUnit.Decimal)).isEqualTo("1 GB")
+    assertThat(Size(-(1000L * 1000 * 1000)).toString(ByteUnit.Decimal)).isEqualTo("-1 GB")
   }
 }

--- a/reports/api/reports.api
+++ b/reports/api/reports.api
@@ -5,6 +5,7 @@ public abstract interface class com/jakewharton/diffuse/diff/BinaryDiff : com/ja
 	public static fun ofApk (Lcom/jakewharton/diffuse/format/Apk;Lcom/jakewharton/diffuse/format/ApiMapping;Lcom/jakewharton/diffuse/format/Apk;Lcom/jakewharton/diffuse/format/ApiMapping;)Lcom/jakewharton/diffuse/diff/BinaryDiff;
 	public static fun ofDex (Lcom/jakewharton/diffuse/format/Dex;Lcom/jakewharton/diffuse/format/ApiMapping;Lcom/jakewharton/diffuse/format/Dex;Lcom/jakewharton/diffuse/format/ApiMapping;)Lcom/jakewharton/diffuse/diff/BinaryDiff;
 	public static fun ofJar (Lcom/jakewharton/diffuse/format/Jar;Lcom/jakewharton/diffuse/format/ApiMapping;Lcom/jakewharton/diffuse/format/Jar;Lcom/jakewharton/diffuse/format/ApiMapping;)Lcom/jakewharton/diffuse/diff/BinaryDiff;
+	public abstract fun toTextReport (ZLcom/jakewharton/diffuse/io/ByteUnit;)Lcom/jakewharton/diffuse/report/Report;
 }
 
 public final class com/jakewharton/diffuse/diff/BinaryDiff$Companion {
@@ -20,25 +21,25 @@ public final class com/jakewharton/diffuse/diff/BinaryDiff$Companion {
 }
 
 public final class com/jakewharton/diffuse/diff/BinaryDiff$DefaultImpls {
-	public static fun toHtmlReport (Lcom/jakewharton/diffuse/diff/BinaryDiff;Z)Lcom/jakewharton/diffuse/report/Report;
+	public static fun toHtmlReport (Lcom/jakewharton/diffuse/diff/BinaryDiff;ZLcom/jakewharton/diffuse/io/ByteUnit;)Lcom/jakewharton/diffuse/report/Report;
 }
 
 public final class com/jakewharton/diffuse/info/AabInfo : com/jakewharton/diffuse/diff/BinaryDiff {
 	public fun <init> (Lcom/jakewharton/diffuse/format/Aab;)V
-	public fun toHtmlReport (Z)Lcom/jakewharton/diffuse/report/Report;
-	public fun toTextReport (Z)Lcom/jakewharton/diffuse/report/Report;
+	public fun toHtmlReport (ZLcom/jakewharton/diffuse/io/ByteUnit;)Lcom/jakewharton/diffuse/report/Report;
+	public fun toTextReport (ZLcom/jakewharton/diffuse/io/ByteUnit;)Lcom/jakewharton/diffuse/report/Report;
 }
 
 public final class com/jakewharton/diffuse/info/AarInfo : com/jakewharton/diffuse/info/BinaryInfo {
 	public fun <init> (Lcom/jakewharton/diffuse/format/Aar;)V
-	public fun toHtmlReport (Z)Lcom/jakewharton/diffuse/report/Report;
-	public fun toTextReport (Z)Lcom/jakewharton/diffuse/report/Report;
+	public fun toHtmlReport (ZLcom/jakewharton/diffuse/io/ByteUnit;)Lcom/jakewharton/diffuse/report/Report;
+	public fun toTextReport (ZLcom/jakewharton/diffuse/io/ByteUnit;)Lcom/jakewharton/diffuse/report/Report;
 }
 
 public final class com/jakewharton/diffuse/info/ApkInfo : com/jakewharton/diffuse/info/BinaryInfo {
 	public fun <init> (Lcom/jakewharton/diffuse/format/Apk;)V
-	public fun toHtmlReport (Z)Lcom/jakewharton/diffuse/report/Report;
-	public fun toTextReport (Z)Lcom/jakewharton/diffuse/report/Report;
+	public fun toHtmlReport (ZLcom/jakewharton/diffuse/io/ByteUnit;)Lcom/jakewharton/diffuse/report/Report;
+	public fun toTextReport (ZLcom/jakewharton/diffuse/io/ByteUnit;)Lcom/jakewharton/diffuse/report/Report;
 }
 
 public abstract interface class com/jakewharton/diffuse/info/BinaryInfo : com/jakewharton/diffuse/report/Report$Factory {
@@ -51,19 +52,19 @@ public final class com/jakewharton/diffuse/info/BinaryInfo$Companion {
 }
 
 public final class com/jakewharton/diffuse/info/BinaryInfo$DefaultImpls {
-	public static fun toHtmlReport (Lcom/jakewharton/diffuse/info/BinaryInfo;Z)Lcom/jakewharton/diffuse/report/Report;
+	public static fun toHtmlReport (Lcom/jakewharton/diffuse/info/BinaryInfo;ZLcom/jakewharton/diffuse/io/ByteUnit;)Lcom/jakewharton/diffuse/report/Report;
 }
 
 public final class com/jakewharton/diffuse/info/DexInfo : com/jakewharton/diffuse/info/BinaryInfo {
 	public fun <init> (Lcom/jakewharton/diffuse/format/Dex;)V
-	public fun toHtmlReport (Z)Lcom/jakewharton/diffuse/report/Report;
-	public fun toTextReport (Z)Lcom/jakewharton/diffuse/report/Report;
+	public fun toHtmlReport (ZLcom/jakewharton/diffuse/io/ByteUnit;)Lcom/jakewharton/diffuse/report/Report;
+	public fun toTextReport (ZLcom/jakewharton/diffuse/io/ByteUnit;)Lcom/jakewharton/diffuse/report/Report;
 }
 
 public final class com/jakewharton/diffuse/info/JarInfo : com/jakewharton/diffuse/info/BinaryInfo {
 	public fun <init> (Lcom/jakewharton/diffuse/format/Jar;)V
-	public fun toHtmlReport (Z)Lcom/jakewharton/diffuse/report/Report;
-	public fun toTextReport (Z)Lcom/jakewharton/diffuse/report/Report;
+	public fun toHtmlReport (ZLcom/jakewharton/diffuse/io/ByteUnit;)Lcom/jakewharton/diffuse/report/Report;
+	public fun toTextReport (ZLcom/jakewharton/diffuse/io/ByteUnit;)Lcom/jakewharton/diffuse/report/Report;
 }
 
 public abstract interface class com/jakewharton/diffuse/report/Report {
@@ -71,16 +72,21 @@ public abstract interface class com/jakewharton/diffuse/report/Report {
 }
 
 public abstract interface class com/jakewharton/diffuse/report/Report$Factory {
-	public fun toHtmlReport (Z)Lcom/jakewharton/diffuse/report/Report;
-	public abstract fun toTextReport (Z)Lcom/jakewharton/diffuse/report/Report;
+	public fun toHtmlReport (ZLcom/jakewharton/diffuse/io/ByteUnit;)Lcom/jakewharton/diffuse/report/Report;
+	public static synthetic fun toHtmlReport$default (Lcom/jakewharton/diffuse/report/Report$Factory;ZLcom/jakewharton/diffuse/io/ByteUnit;ILjava/lang/Object;)Lcom/jakewharton/diffuse/report/Report;
+	public abstract fun toTextReport (ZLcom/jakewharton/diffuse/io/ByteUnit;)Lcom/jakewharton/diffuse/report/Report;
+	public static synthetic fun toTextReport$default (Lcom/jakewharton/diffuse/report/Report$Factory;ZLcom/jakewharton/diffuse/io/ByteUnit;ILjava/lang/Object;)Lcom/jakewharton/diffuse/report/Report;
 }
 
 public final class com/jakewharton/diffuse/report/Report$Factory$DefaultImpls {
-	public static fun toHtmlReport (Lcom/jakewharton/diffuse/report/Report$Factory;Z)Lcom/jakewharton/diffuse/report/Report;
+	public static fun toHtmlReport (Lcom/jakewharton/diffuse/report/Report$Factory;ZLcom/jakewharton/diffuse/io/ByteUnit;)Lcom/jakewharton/diffuse/report/Report;
+	public static synthetic fun toHtmlReport$default (Lcom/jakewharton/diffuse/report/Report$Factory;ZLcom/jakewharton/diffuse/io/ByteUnit;ILjava/lang/Object;)Lcom/jakewharton/diffuse/report/Report;
+	public static synthetic fun toTextReport$default (Lcom/jakewharton/diffuse/report/Report$Factory;ZLcom/jakewharton/diffuse/io/ByteUnit;ILjava/lang/Object;)Lcom/jakewharton/diffuse/report/Report;
 }
 
 public final class com/jakewharton/diffuse/report/text/ApkInfoTextReport : com/jakewharton/diffuse/report/Report {
-	public fun <init> (Lcom/jakewharton/diffuse/format/Apk;)V
+	public fun <init> (Lcom/jakewharton/diffuse/format/Apk;Lcom/jakewharton/diffuse/io/ByteUnit;)V
+	public synthetic fun <init> (Lcom/jakewharton/diffuse/format/Apk;Lcom/jakewharton/diffuse/io/ByteUnit;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun toString ()Ljava/lang/String;
 	public fun write (Ljava/lang/Appendable;)V
 }

--- a/reports/src/main/kotlin/com/jakewharton/diffuse/diff/AabDiff.kt
+++ b/reports/src/main/kotlin/com/jakewharton/diffuse/diff/AabDiff.kt
@@ -1,6 +1,7 @@
 package com.jakewharton.diffuse.diff
 
 import com.jakewharton.diffuse.format.Aab
+import com.jakewharton.diffuse.io.ByteUnit
 import com.jakewharton.diffuse.report.Report
 import com.jakewharton.diffuse.report.text.AabDiffTextReport
 
@@ -29,5 +30,6 @@ internal class AabDiff(val oldAab: Aab, val newAab: Aab) : BinaryDiff {
         ModuleDiff(oldModule, newAab.featureModules.getValue(name))
       }
 
-  override fun toTextReport(summaryOnly: Boolean): Report = AabDiffTextReport(this, summaryOnly)
+  override fun toTextReport(summaryOnly: Boolean, byteUnit: ByteUnit): Report =
+    AabDiffTextReport(this, summaryOnly, byteUnit)
 }

--- a/reports/src/main/kotlin/com/jakewharton/diffuse/diff/AarDiff.kt
+++ b/reports/src/main/kotlin/com/jakewharton/diffuse/diff/AarDiff.kt
@@ -2,6 +2,7 @@ package com.jakewharton.diffuse.diff
 
 import com.jakewharton.diffuse.format.Aar
 import com.jakewharton.diffuse.format.ApiMapping
+import com.jakewharton.diffuse.io.ByteUnit
 import com.jakewharton.diffuse.report.Report
 import com.jakewharton.diffuse.report.text.AarDiffTextReport
 
@@ -15,5 +16,6 @@ internal class AarDiff(
   val jars = JarsDiff(oldAar.jars, oldMapping, newAar.jars, newMapping)
   val manifest = ManifestDiff(oldAar.manifest, newAar.manifest)
 
-  override fun toTextReport(summaryOnly: Boolean): Report = AarDiffTextReport(this, summaryOnly)
+  override fun toTextReport(summaryOnly: Boolean, byteUnit: ByteUnit): Report =
+    AarDiffTextReport(this, summaryOnly, byteUnit)
 }

--- a/reports/src/main/kotlin/com/jakewharton/diffuse/diff/ApkDiff.kt
+++ b/reports/src/main/kotlin/com/jakewharton/diffuse/diff/ApkDiff.kt
@@ -3,6 +3,7 @@ package com.jakewharton.diffuse.diff
 import com.jakewharton.diffuse.diff.lint.resourcesArscCompression
 import com.jakewharton.diffuse.format.ApiMapping
 import com.jakewharton.diffuse.format.Apk
+import com.jakewharton.diffuse.io.ByteUnit
 import com.jakewharton.diffuse.report.Report
 import com.jakewharton.diffuse.report.text.ApkDiffTextReport
 
@@ -24,5 +25,6 @@ internal class ApkDiff(
 
   val lintMessages = listOfNotNull(archive.resourcesArscCompression())
 
-  override fun toTextReport(summaryOnly: Boolean): Report = ApkDiffTextReport(this, summaryOnly)
+  override fun toTextReport(summaryOnly: Boolean, byteUnit: ByteUnit): Report =
+    ApkDiffTextReport(this, summaryOnly, byteUnit)
 }

--- a/reports/src/main/kotlin/com/jakewharton/diffuse/diff/ArchiveFilesDiff.kt
+++ b/reports/src/main/kotlin/com/jakewharton/diffuse/diff/ArchiveFilesDiff.kt
@@ -4,6 +4,7 @@ import com.jakewharton.diffuse.diff.ArchiveFilesDiff.Change
 import com.jakewharton.diffuse.diffuseTable
 import com.jakewharton.diffuse.format.ArchiveFile.Type
 import com.jakewharton.diffuse.format.ArchiveFiles
+import com.jakewharton.diffuse.io.ByteUnit
 import com.jakewharton.diffuse.io.Size
 import com.jakewharton.diffuse.report.toDiffString
 import com.jakewharton.picnic.TableSectionDsl
@@ -98,6 +99,7 @@ internal fun ArchiveFilesDiff.toSummaryTable(
   name: String,
   displayTypes: List<Type>,
   skipIfEmptyTypes: Set<Type> = emptySet(),
+  byteUnit: ByteUnit = ByteUnit.Binary,
 ) =
   diffuseTable {
       header {
@@ -137,19 +139,24 @@ internal fun ArchiveFilesDiff.toSummaryTable(
         val newUncompressedSize =
           new.values.fold(Size.ZERO) { acc, file -> acc + file.uncompressedSize }
         if (oldSize != Size.ZERO || newSize != Size.ZERO || type !in skipIfEmptyTypes) {
-          val uncompressedDiff = (newUncompressedSize - oldUncompressedSize).toDiffString()
+          val uncompressedDiff = (newUncompressedSize - oldUncompressedSize).toDiffString(byteUnit)
           if (includeCompressed) {
             row(
               name,
-              oldSize,
-              newSize,
-              (newSize - oldSize).toDiffString(),
-              oldUncompressedSize,
-              newUncompressedSize,
+              oldSize.toString(byteUnit),
+              newSize.toString(byteUnit),
+              (newSize - oldSize).toDiffString(byteUnit),
+              oldUncompressedSize.toString(byteUnit),
+              newUncompressedSize.toString(byteUnit),
               uncompressedDiff,
             )
           } else {
-            row(name, oldUncompressedSize, newUncompressedSize, uncompressedDiff)
+            row(
+              name,
+              oldUncompressedSize.toString(byteUnit),
+              newUncompressedSize.toString(byteUnit),
+              uncompressedDiff,
+            )
           }
         }
       }
@@ -168,7 +175,7 @@ internal fun ArchiveFilesDiff.toSummaryTable(
     }
     .renderText()
 
-internal fun ArchiveFilesDiff.toDetailReport() = buildString {
+internal fun ArchiveFilesDiff.toDetailReport(byteUnit: ByteUnit = ByteUnit.Binary) = buildString {
   appendLine()
   appendLine(
     diffuseTable {
@@ -202,15 +209,15 @@ internal fun ArchiveFilesDiff.toDetailReport() = buildString {
             if (includeCompressed) {
               val totalSize = changes.fold(Size.ZERO) { acc, change -> acc + change.size }
               val totalDiff = changes.fold(Size.ZERO) { acc, change -> acc + change.sizeDiff }
-              cell(totalSize) { alignment = MiddleRight }
-              cell(totalDiff.toDiffString()) { alignment = MiddleRight }
+              cell(totalSize.toString(byteUnit)) { alignment = MiddleRight }
+              cell(totalDiff.toDiffString(byteUnit)) { alignment = MiddleRight }
             }
             val totalUncompressedSize =
               changes.fold(Size.ZERO) { acc, change -> acc + change.uncompressedSize }
             val totalUncompressedDiff =
               changes.fold(Size.ZERO) { acc, change -> acc + change.uncompressedSizeDiff }
-            cell(totalUncompressedSize) { alignment = MiddleRight }
-            cell(totalUncompressedDiff.toDiffString()) { alignment = MiddleRight }
+            cell(totalUncompressedSize.toString(byteUnit)) { alignment = MiddleRight }
+            cell(totalUncompressedDiff.toDiffString(byteUnit)) { alignment = MiddleRight }
             cell("(total)")
           }
         }
@@ -223,13 +230,15 @@ internal fun ArchiveFilesDiff.toDetailReport() = buildString {
             }
           row {
             if (includeCompressed) {
-              cell(if (type != Change.Type.Removed) size else "") { alignment = MiddleRight }
-              cell(sizeDiff.toDiffString()) { alignment = MiddleRight }
+              cell(if (type != Change.Type.Removed) size.toString(byteUnit) else "") {
+                alignment = MiddleRight
+              }
+              cell(sizeDiff.toDiffString(byteUnit)) { alignment = MiddleRight }
             }
-            cell(if (type != Change.Type.Removed) uncompressedSize else "") {
+            cell(if (type != Change.Type.Removed) uncompressedSize.toString(byteUnit) else "") {
               alignment = MiddleRight
             }
-            cell(uncompressedSizeDiff.toDiffString()) { alignment = MiddleRight }
+            cell(uncompressedSizeDiff.toDiffString(byteUnit)) { alignment = MiddleRight }
             cell("$typeChar $path")
           }
         }

--- a/reports/src/main/kotlin/com/jakewharton/diffuse/diff/BinaryDiff.kt
+++ b/reports/src/main/kotlin/com/jakewharton/diffuse/diff/BinaryDiff.kt
@@ -6,9 +6,12 @@ import com.jakewharton.diffuse.format.ApiMapping
 import com.jakewharton.diffuse.format.Apk
 import com.jakewharton.diffuse.format.Dex
 import com.jakewharton.diffuse.format.Jar
+import com.jakewharton.diffuse.io.ByteUnit
 import com.jakewharton.diffuse.report.Report
 
 interface BinaryDiff : Report.Factory {
+  override fun toTextReport(summaryOnly: Boolean, byteUnit: ByteUnit): Report
+
   companion object {
     @JvmStatic
     fun ofApk(

--- a/reports/src/main/kotlin/com/jakewharton/diffuse/diff/DexDiff.kt
+++ b/reports/src/main/kotlin/com/jakewharton/diffuse/diff/DexDiff.kt
@@ -4,6 +4,7 @@ import com.jakewharton.diffuse.diffuseTable
 import com.jakewharton.diffuse.format.Dex
 import com.jakewharton.diffuse.format.Field
 import com.jakewharton.diffuse.format.Method
+import com.jakewharton.diffuse.io.ByteUnit
 import com.jakewharton.diffuse.report.Report
 import com.jakewharton.diffuse.report.text.DexDiffTextReport
 import com.jakewharton.diffuse.report.toDiffString
@@ -32,7 +33,8 @@ internal class DexDiff(val oldDexes: List<Dex>, val newDexes: List<Dex>) : Binar
 
   val changed = strings.changed || types.changed || methods.changed || fields.changed
 
-  override fun toTextReport(summaryOnly: Boolean): Report = DexDiffTextReport(this, summaryOnly)
+  override fun toTextReport(summaryOnly: Boolean, byteUnit: ByteUnit): Report =
+    DexDiffTextReport(this, summaryOnly, byteUnit)
 }
 
 internal fun DexDiff.toSummaryTable() =

--- a/reports/src/main/kotlin/com/jakewharton/diffuse/diff/JarDiff.kt
+++ b/reports/src/main/kotlin/com/jakewharton/diffuse/diff/JarDiff.kt
@@ -2,6 +2,7 @@ package com.jakewharton.diffuse.diff
 
 import com.jakewharton.diffuse.format.ApiMapping
 import com.jakewharton.diffuse.format.Jar
+import com.jakewharton.diffuse.io.ByteUnit
 import com.jakewharton.diffuse.report.Report
 import com.jakewharton.diffuse.report.text.JarDiffTextReport
 
@@ -16,5 +17,6 @@ internal class JarDiff(
 
   val changed = jars.changed || archive.changed
 
-  override fun toTextReport(summaryOnly: Boolean): Report = JarDiffTextReport(this, summaryOnly)
+  override fun toTextReport(summaryOnly: Boolean, byteUnit: ByteUnit): Report =
+    JarDiffTextReport(this, summaryOnly, byteUnit)
 }

--- a/reports/src/main/kotlin/com/jakewharton/diffuse/info/AabInfo.kt
+++ b/reports/src/main/kotlin/com/jakewharton/diffuse/info/AabInfo.kt
@@ -2,11 +2,12 @@ package com.jakewharton.diffuse.info
 
 import com.jakewharton.diffuse.diff.BinaryDiff
 import com.jakewharton.diffuse.format.Aab
+import com.jakewharton.diffuse.io.ByteUnit
 import com.jakewharton.diffuse.report.Report
 import com.jakewharton.diffuse.report.text.AabInfoTextReport
 
 class AabInfo(private val aab: Aab) : BinaryDiff {
-  override fun toTextReport(summaryOnly: Boolean): Report {
-    return AabInfoTextReport(aab)
+  override fun toTextReport(summaryOnly: Boolean, byteUnit: ByteUnit): Report {
+    return AabInfoTextReport(aab, byteUnit)
   }
 }

--- a/reports/src/main/kotlin/com/jakewharton/diffuse/info/AarInfo.kt
+++ b/reports/src/main/kotlin/com/jakewharton/diffuse/info/AarInfo.kt
@@ -1,11 +1,12 @@
 package com.jakewharton.diffuse.info
 
 import com.jakewharton.diffuse.format.Aar
+import com.jakewharton.diffuse.io.ByteUnit
 import com.jakewharton.diffuse.report.Report
 import com.jakewharton.diffuse.report.text.AarInfoTextReport
 
 class AarInfo(private val aar: Aar) : BinaryInfo {
-  override fun toTextReport(summaryOnly: Boolean): Report {
-    return AarInfoTextReport(aar)
+  override fun toTextReport(summaryOnly: Boolean, byteUnit: ByteUnit): Report {
+    return AarInfoTextReport(aar, byteUnit)
   }
 }

--- a/reports/src/main/kotlin/com/jakewharton/diffuse/info/ApkInfo.kt
+++ b/reports/src/main/kotlin/com/jakewharton/diffuse/info/ApkInfo.kt
@@ -1,11 +1,12 @@
 package com.jakewharton.diffuse.info
 
 import com.jakewharton.diffuse.format.Apk
+import com.jakewharton.diffuse.io.ByteUnit
 import com.jakewharton.diffuse.report.Report
 import com.jakewharton.diffuse.report.text.ApkInfoTextReport
 
 class ApkInfo(private val apk: Apk) : BinaryInfo {
-  override fun toTextReport(summaryOnly: Boolean): Report {
-    return ApkInfoTextReport(apk)
+  override fun toTextReport(summaryOnly: Boolean, byteUnit: ByteUnit): Report {
+    return ApkInfoTextReport(apk, byteUnit)
   }
 }

--- a/reports/src/main/kotlin/com/jakewharton/diffuse/info/ArchiveFilesInfo.kt
+++ b/reports/src/main/kotlin/com/jakewharton/diffuse/info/ArchiveFilesInfo.kt
@@ -3,6 +3,7 @@ package com.jakewharton.diffuse.info
 import com.jakewharton.diffuse.diffuseTable
 import com.jakewharton.diffuse.format.ArchiveFile
 import com.jakewharton.diffuse.format.ArchiveFiles
+import com.jakewharton.diffuse.io.ByteUnit
 import com.jakewharton.diffuse.io.Size
 import com.jakewharton.picnic.TableSectionDsl
 import com.jakewharton.picnic.TextAlignment
@@ -13,6 +14,7 @@ internal fun ArchiveFiles.toSummaryTable(
   displayTypes: List<ArchiveFile.Type>,
   skipIfEmptyTypes: Set<ArchiveFile.Type> = emptySet(),
   includeCompressed: Boolean = true,
+  byteUnit: ByteUnit = ByteUnit.Binary,
 ) =
   diffuseTable {
       header {
@@ -37,9 +39,9 @@ internal fun ArchiveFiles.toSummaryTable(
           old.values.fold(Size.ZERO) { acc, file -> acc + file.uncompressedSize }
         if (oldSize != Size.ZERO || type !in skipIfEmptyTypes) {
           if (includeCompressed) {
-            row(name, oldSize, oldUncompressedSize)
+            row(name, oldSize.toString(byteUnit), oldUncompressedSize.toString(byteUnit))
           } else {
-            row(name, oldUncompressedSize)
+            row(name, oldUncompressedSize.toString(byteUnit))
           }
         }
       }

--- a/reports/src/main/kotlin/com/jakewharton/diffuse/info/DexInfo.kt
+++ b/reports/src/main/kotlin/com/jakewharton/diffuse/info/DexInfo.kt
@@ -1,11 +1,12 @@
 package com.jakewharton.diffuse.info
 
 import com.jakewharton.diffuse.format.Dex
+import com.jakewharton.diffuse.io.ByteUnit
 import com.jakewharton.diffuse.report.Report
 import com.jakewharton.diffuse.report.text.DexInfoTextReport
 
 class DexInfo(private val dex: Dex) : BinaryInfo {
-  override fun toTextReport(summaryOnly: Boolean): Report {
-    return DexInfoTextReport(dex)
+  override fun toTextReport(summaryOnly: Boolean, byteUnit: ByteUnit): Report {
+    return DexInfoTextReport(dex, byteUnit)
   }
 }

--- a/reports/src/main/kotlin/com/jakewharton/diffuse/info/JarInfo.kt
+++ b/reports/src/main/kotlin/com/jakewharton/diffuse/info/JarInfo.kt
@@ -1,11 +1,12 @@
 package com.jakewharton.diffuse.info
 
 import com.jakewharton.diffuse.format.Jar
+import com.jakewharton.diffuse.io.ByteUnit
 import com.jakewharton.diffuse.report.Report
 import com.jakewharton.diffuse.report.text.JarInfoTextReport
 
 class JarInfo(private val jar: Jar) : BinaryInfo {
-  override fun toTextReport(summaryOnly: Boolean): Report {
-    return JarInfoTextReport(jar)
+  override fun toTextReport(summaryOnly: Boolean, byteUnit: ByteUnit): Report {
+    return JarInfoTextReport(jar, byteUnit)
   }
 }

--- a/reports/src/main/kotlin/com/jakewharton/diffuse/report/Report.kt
+++ b/reports/src/main/kotlin/com/jakewharton/diffuse/report/Report.kt
@@ -1,12 +1,14 @@
 package com.jakewharton.diffuse.report
 
+import com.jakewharton.diffuse.io.ByteUnit
+
 interface Report {
   fun write(appendable: Appendable)
 
   interface Factory {
-    fun toTextReport(summaryOnly: Boolean): Report
+    fun toTextReport(summaryOnly: Boolean = false, byteUnit: ByteUnit = ByteUnit.Binary): Report
 
-    fun toHtmlReport(summaryOnly: Boolean): Report {
+    fun toHtmlReport(summaryOnly: Boolean = false, byteUnit: ByteUnit = ByteUnit.Binary): Report {
       TODO("Implement HTML reporting")
     }
   }

--- a/reports/src/main/kotlin/com/jakewharton/diffuse/report/strings.kt
+++ b/reports/src/main/kotlin/com/jakewharton/diffuse/report/strings.kt
@@ -1,5 +1,6 @@
 package com.jakewharton.diffuse.report
 
+import com.jakewharton.diffuse.io.ByteUnit
 import com.jakewharton.diffuse.io.Size
 
 internal fun Int.toUnitString(unit: String, vararg specializations: Pair<Int, String>): String {
@@ -19,9 +20,9 @@ internal fun Int.toDiffString(zeroSign: Char? = null) = buildString {
   append(this@toDiffString)
 }
 
-internal fun Size.toDiffString() = buildString {
+internal fun Size.toDiffString(byteUnit: ByteUnit = ByteUnit.Binary) = buildString {
   if (bytes > 0L) {
     append('+')
   }
-  append(this@toDiffString)
+  append(toString(byteUnit))
 }

--- a/reports/src/main/kotlin/com/jakewharton/diffuse/report/text/AabDiffTextReport.kt
+++ b/reports/src/main/kotlin/com/jakewharton/diffuse/report/text/AabDiffTextReport.kt
@@ -3,13 +3,17 @@ package com.jakewharton.diffuse.report.text
 import com.jakewharton.diffuse.diff.AabDiff
 import com.jakewharton.diffuse.diff.toDetailReport
 import com.jakewharton.diffuse.diffuseTable
+import com.jakewharton.diffuse.io.ByteUnit
 import com.jakewharton.diffuse.report.Report
 import com.jakewharton.picnic.TextAlignment.BottomLeft
 import com.jakewharton.picnic.TextAlignment.MiddleCenter
 import com.jakewharton.picnic.TextAlignment.MiddleRight
 
-internal class AabDiffTextReport(private val aabDiff: AabDiff, private val summaryOnly: Boolean) :
-  Report {
+internal class AabDiffTextReport(
+  private val aabDiff: AabDiff,
+  private val summaryOnly: Boolean,
+  private val byteUnit: ByteUnit = ByteUnit.Binary,
+) : Report {
   override fun write(appendable: Appendable) {
     appendable.apply {
       append("OLD: ")
@@ -55,7 +59,7 @@ internal class AabDiffTextReport(private val aabDiff: AabDiff, private val summa
       appendLine("==================")
       appendLine()
       if (aabDiff.baseModule.archive.changed) {
-        appendLine(aabDiff.baseModule.archive.toDetailReport())
+        appendLine(aabDiff.baseModule.archive.toDetailReport(byteUnit))
       }
       if (aabDiff.baseModule.dex.changed) {
         appendLine(aabDiff.baseModule.dex.toDetailReport())
@@ -81,7 +85,7 @@ internal class AabDiffTextReport(private val aabDiff: AabDiff, private val summa
         }
         if (changedModule != null) {
           if (changedModule.archive.changed) {
-            appendLine(changedModule.archive.toDetailReport())
+            appendLine(changedModule.archive.toDetailReport(byteUnit))
           }
           if (changedModule.dex.changed) {
             appendLine(changedModule.dex.toDetailReport())

--- a/reports/src/main/kotlin/com/jakewharton/diffuse/report/text/AabInfoTextReport.kt
+++ b/reports/src/main/kotlin/com/jakewharton/diffuse/report/text/AabInfoTextReport.kt
@@ -4,9 +4,13 @@ import com.jakewharton.diffuse.diffuseTable
 import com.jakewharton.diffuse.format.Aab
 import com.jakewharton.diffuse.format.ArchiveFile
 import com.jakewharton.diffuse.info.toSummaryTable
+import com.jakewharton.diffuse.io.ByteUnit
 import com.jakewharton.diffuse.report.Report
 
-internal class AabInfoTextReport(private val aab: Aab) : Report {
+internal class AabInfoTextReport(
+  private val aab: Aab,
+  private val byteUnit: ByteUnit = ByteUnit.Binary,
+) : Report {
   override fun write(appendable: Appendable) {
     appendable.apply {
       appendLine(aab.filename)
@@ -45,6 +49,7 @@ internal class AabInfoTextReport(private val aab: Aab) : Report {
         "AAB",
         ArchiveFile.Type.AAB_TYPES,
         skipIfEmptyTypes = setOf(ArchiveFile.Type.Native),
+        byteUnit = byteUnit,
       )
     )
     appendLine(module.dexes.toSummaryTable())

--- a/reports/src/main/kotlin/com/jakewharton/diffuse/report/text/AarDiffTextReport.kt
+++ b/reports/src/main/kotlin/com/jakewharton/diffuse/report/text/AarDiffTextReport.kt
@@ -4,10 +4,14 @@ import com.jakewharton.diffuse.diff.AarDiff
 import com.jakewharton.diffuse.diff.toDetailReport
 import com.jakewharton.diffuse.diff.toSummaryTable
 import com.jakewharton.diffuse.format.ArchiveFile.Type
+import com.jakewharton.diffuse.io.ByteUnit
 import com.jakewharton.diffuse.report.Report
 
-internal class AarDiffTextReport(private val aarDiff: AarDiff, private val summaryOnly: Boolean) :
-  Report {
+internal class AarDiffTextReport(
+  private val aarDiff: AarDiff,
+  private val summaryOnly: Boolean,
+  private val byteUnit: ByteUnit = ByteUnit.Binary,
+) : Report {
   override fun write(appendable: Appendable) {
     appendable.apply {
       append("OLD: ")
@@ -22,6 +26,7 @@ internal class AarDiffTextReport(private val aarDiff: AarDiff, private val summa
           "AAR",
           Type.AAR_TYPES,
           skipIfEmptyTypes = setOf(Type.JarLibs, Type.ApiJar, Type.LintJar, Type.Native, Type.Res),
+          byteUnit = byteUnit,
         )
       )
       appendLine()
@@ -33,7 +38,7 @@ internal class AarDiffTextReport(private val aarDiff: AarDiff, private val summa
         appendLine("=================")
         appendLine("====   AAR   ====")
         appendLine("=================")
-        appendLine(aarDiff.archive.toDetailReport())
+        appendLine(aarDiff.archive.toDetailReport(byteUnit))
       }
       if (aarDiff.manifest.changed) {
         appendLine()

--- a/reports/src/main/kotlin/com/jakewharton/diffuse/report/text/AarInfoTextReport.kt
+++ b/reports/src/main/kotlin/com/jakewharton/diffuse/report/text/AarInfoTextReport.kt
@@ -3,9 +3,13 @@ package com.jakewharton.diffuse.report.text
 import com.jakewharton.diffuse.format.Aar
 import com.jakewharton.diffuse.format.ArchiveFile.Type
 import com.jakewharton.diffuse.info.toSummaryTable
+import com.jakewharton.diffuse.io.ByteUnit
 import com.jakewharton.diffuse.report.Report
 
-internal class AarInfoTextReport(private val aar: Aar) : Report {
+internal class AarInfoTextReport(
+  private val aar: Aar,
+  private val byteUnit: ByteUnit = ByteUnit.Binary,
+) : Report {
   override fun write(appendable: Appendable) {
     appendable.apply {
       appendLine(aar.filename)
@@ -15,6 +19,7 @@ internal class AarInfoTextReport(private val aar: Aar) : Report {
           "AAR",
           Type.AAR_TYPES,
           skipIfEmptyTypes = setOf(Type.JarLibs, Type.ApiJar, Type.LintJar, Type.Native, Type.Res),
+          byteUnit = byteUnit,
         )
       )
       appendLine()

--- a/reports/src/main/kotlin/com/jakewharton/diffuse/report/text/ApkDiffTextReport.kt
+++ b/reports/src/main/kotlin/com/jakewharton/diffuse/report/text/ApkDiffTextReport.kt
@@ -6,11 +6,15 @@ import com.jakewharton.diffuse.diff.toDetailReport
 import com.jakewharton.diffuse.diff.toSummaryTable
 import com.jakewharton.diffuse.diffuseTable
 import com.jakewharton.diffuse.format.ArchiveFile.Type
+import com.jakewharton.diffuse.io.ByteUnit
 import com.jakewharton.diffuse.report.Report
 import com.jakewharton.diffuse.report.toSummaryString
 
-internal class ApkDiffTextReport(private val apkDiff: ApkDiff, private val summaryOnly: Boolean) :
-  Report {
+internal class ApkDiffTextReport(
+  private val apkDiff: ApkDiff,
+  private val summaryOnly: Boolean,
+  private val byteUnit: ByteUnit = ByteUnit.Binary,
+) : Report {
   override fun write(appendable: Appendable) {
     appendable.apply {
       append("OLD: ")
@@ -53,7 +57,12 @@ internal class ApkDiffTextReport(private val apkDiff: ApkDiff, private val summa
         appendLine()
       }
       appendLine(
-        apkDiff.archive.toSummaryTable("APK", Type.APK_TYPES, skipIfEmptyTypes = setOf(Type.Native))
+        apkDiff.archive.toSummaryTable(
+          "APK",
+          Type.APK_TYPES,
+          skipIfEmptyTypes = setOf(Type.Native),
+          byteUnit = byteUnit,
+        )
       )
       appendLine()
       appendLine(apkDiff.dex.toSummaryTable())
@@ -67,7 +76,7 @@ internal class ApkDiffTextReport(private val apkDiff: ApkDiff, private val summa
         appendLine("====   APK   ====")
         appendLine("=================")
         if (apkDiff.archive.changed) {
-          appendLine(apkDiff.archive.toDetailReport())
+          appendLine(apkDiff.archive.toDetailReport(byteUnit))
         }
         if (apkDiff.signatures.changed) {
           appendLine(apkDiff.signatures.toDetailReport())

--- a/reports/src/main/kotlin/com/jakewharton/diffuse/report/text/ApkInfoTextReport.kt
+++ b/reports/src/main/kotlin/com/jakewharton/diffuse/report/text/ApkInfoTextReport.kt
@@ -3,10 +3,12 @@ package com.jakewharton.diffuse.report.text
 import com.jakewharton.diffuse.format.Apk
 import com.jakewharton.diffuse.format.ArchiveFile
 import com.jakewharton.diffuse.info.toSummaryTable
+import com.jakewharton.diffuse.io.ByteUnit
 import com.jakewharton.diffuse.report.Report
 import com.jakewharton.diffuse.report.toSummaryString
 
-class ApkInfoTextReport(private val apk: Apk) : Report {
+class ApkInfoTextReport(private val apk: Apk, private val byteUnit: ByteUnit = ByteUnit.Binary) :
+  Report {
   override fun write(appendable: Appendable) {
     appendable.apply {
       append(apk.filename)
@@ -20,6 +22,7 @@ class ApkInfoTextReport(private val apk: Apk) : Report {
           "APK",
           ArchiveFile.Type.APK_TYPES,
           skipIfEmptyTypes = setOf(ArchiveFile.Type.Native),
+          byteUnit = byteUnit,
         )
       )
       appendLine()

--- a/reports/src/main/kotlin/com/jakewharton/diffuse/report/text/DexDiffTextReport.kt
+++ b/reports/src/main/kotlin/com/jakewharton/diffuse/report/text/DexDiffTextReport.kt
@@ -2,10 +2,14 @@ package com.jakewharton.diffuse.report.text
 
 import com.jakewharton.diffuse.diff.DexDiff
 import com.jakewharton.diffuse.diff.toDetailReport
+import com.jakewharton.diffuse.io.ByteUnit
 import com.jakewharton.diffuse.report.Report
 
-internal class DexDiffTextReport(private val dexDiff: DexDiff, private val summaryOnly: Boolean) :
-  Report {
+internal class DexDiffTextReport(
+  private val dexDiff: DexDiff,
+  private val summaryOnly: Boolean,
+  private val byteUnit: ByteUnit = ByteUnit.Binary,
+) : Report {
   private val oldDex =
     requireNotNull(dexDiff.oldDexes.singleOrNull()) {
       "Dex diff report only supports a single old dex. Found: ${dexDiff.oldDexes}"

--- a/reports/src/main/kotlin/com/jakewharton/diffuse/report/text/DexInfoTextReport.kt
+++ b/reports/src/main/kotlin/com/jakewharton/diffuse/report/text/DexInfoTextReport.kt
@@ -2,9 +2,13 @@ package com.jakewharton.diffuse.report.text
 
 import com.jakewharton.diffuse.format.Dex
 import com.jakewharton.diffuse.info.toSummaryTable
+import com.jakewharton.diffuse.io.ByteUnit
 import com.jakewharton.diffuse.report.Report
 
-internal class DexInfoTextReport(private val dex: Dex) : Report {
+internal class DexInfoTextReport(
+  private val dex: Dex,
+  private val byteUnit: ByteUnit = ByteUnit.Binary,
+) : Report {
   override fun write(appendable: Appendable) {
     appendable.apply {
       appendLine(dex.filename)

--- a/reports/src/main/kotlin/com/jakewharton/diffuse/report/text/JarDiffTextReport.kt
+++ b/reports/src/main/kotlin/com/jakewharton/diffuse/report/text/JarDiffTextReport.kt
@@ -4,10 +4,14 @@ import com.jakewharton.diffuse.diff.JarDiff
 import com.jakewharton.diffuse.diff.toDetailReport
 import com.jakewharton.diffuse.diff.toSummaryTable
 import com.jakewharton.diffuse.format.ArchiveFile.Type
+import com.jakewharton.diffuse.io.ByteUnit
 import com.jakewharton.diffuse.report.Report
 
-internal class JarDiffTextReport(private val jarDiff: JarDiff, private val summaryOnly: Boolean) :
-  Report {
+internal class JarDiffTextReport(
+  private val jarDiff: JarDiff,
+  private val summaryOnly: Boolean,
+  private val byteUnit: ByteUnit = ByteUnit.Binary,
+) : Report {
   override fun write(appendable: Appendable) {
     appendable.apply {
       append("OLD: ")
@@ -17,7 +21,7 @@ internal class JarDiffTextReport(private val jarDiff: JarDiff, private val summa
       appendLine(jarDiff.newJar.filename)
 
       appendLine()
-      appendLine(jarDiff.archive.toSummaryTable("JAR", Type.JAR_TYPES))
+      appendLine(jarDiff.archive.toSummaryTable("JAR", Type.JAR_TYPES, byteUnit = byteUnit))
       appendLine()
       appendLine(jarDiff.jars.toSummaryTable("CLASSES"))
 
@@ -27,7 +31,7 @@ internal class JarDiffTextReport(private val jarDiff: JarDiff, private val summa
         appendLine("=================")
         appendLine("====   JAR   ====")
         appendLine("=================")
-        appendLine(jarDiff.archive.toDetailReport())
+        appendLine(jarDiff.archive.toDetailReport(byteUnit))
       }
       if (jarDiff.jars.changed) {
         appendLine()

--- a/reports/src/main/kotlin/com/jakewharton/diffuse/report/text/JarInfoTextReport.kt
+++ b/reports/src/main/kotlin/com/jakewharton/diffuse/report/text/JarInfoTextReport.kt
@@ -3,14 +3,18 @@ package com.jakewharton.diffuse.report.text
 import com.jakewharton.diffuse.format.ArchiveFile.Type
 import com.jakewharton.diffuse.format.Jar
 import com.jakewharton.diffuse.info.toSummaryTable
+import com.jakewharton.diffuse.io.ByteUnit
 import com.jakewharton.diffuse.report.Report
 
-internal class JarInfoTextReport(private val jar: Jar) : Report {
+internal class JarInfoTextReport(
+  private val jar: Jar,
+  private val byteUnit: ByteUnit = ByteUnit.Binary,
+) : Report {
   override fun write(appendable: Appendable) {
     appendable.apply {
       appendLine(jar.filename)
       appendLine()
-      appendLine(jar.files.toSummaryTable("JAR", Type.JAR_TYPES))
+      appendLine(jar.files.toSummaryTable("JAR", Type.JAR_TYPES, byteUnit = byteUnit))
       appendLine()
       appendLine(listOf(jar).toSummaryTable("CLASSES"))
     }


### PR DESCRIPTION
```
sh ~/IdeaProjects/diffuse/diffuse/build/install/diffuse/bin/diffuse diff --byte-unit decimal --summary-only old.apk new.apk

OLD: old.apk (signature: V2)
NEW: new.apk (signature: V2)

          │             compressed             │            uncompressed
          ├───────────┬───────────┬────────────┼───────────┬───────────┬────────────
 APK      │ old       │ new       │ diff       │ old       │ new       │ diff
──────────┼───────────┼───────────┼────────────┼───────────┼───────────┼────────────
      dex │   1.62 MB │    1.7 MB │  +80.17 KB │   3.27 MB │    3.4 MB │ +126.36 KB
     arsc │   1.78 MB │   1.91 MB │ +133.66 KB │   1.78 MB │   1.91 MB │ +133.66 KB
 manifest │   3.64 KB │   3.64 KB │       +2 B │  16.35 KB │  16.35 KB │        0 B
      res │   9.83 MB │  10.65 MB │ +826.28 KB │  23.27 MB │  25.43 MB │   +2.16 MB
   native │ 103.84 KB │ 107.24 KB │    +3.4 KB │  37.39 KB │  37.39 KB │        0 B
    asset │  52.74 KB │  53.02 KB │     +271 B │ 212.29 KB │ 222.13 KB │   +9.84 KB
    other │  49.05 KB │  48.03 KB │   -1.02 KB │  106.3 KB │ 106.86 KB │     +557 B
──────────┼───────────┼───────────┼────────────┼───────────┼───────────┼────────────
    total │  13.44 MB │  14.48 MB │   +1.04 MB │   28.7 MB │  31.12 MB │   +2.43 MB

 DEX     │ old   │ new   │ diff
─────────┼───────┼───────┼──────────────────────
   files │     1 │     1 │    0
 strings │ 14573 │ 14634 │  +61 (+3963 -3902)
   types │  4889 │  5021 │ +132 (+2832 -2700)
 classes │  4014 │  4122 │ +108 (+2686 -2578)
 methods │ 20139 │ 20965 │ +826 (+17701 -16875)
  fields │ 13961 │ 14270 │ +309 (+13746 -13437)

 ARSC    │ old   │ new   │ diff
─────────┼───────┼───────┼────────────────────
 configs │   149 │   148 │    -1 (+1 -2)
 entries │ 15735 │ 17224 │ +1489 (+1601 -112)
```